### PR TITLE
Use URL instead of path for http get action and change probe-period

### DIFF
--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -26,7 +26,7 @@ const (
 	appliedChecksumKey   = "applied-checksum"
 	appliedOutputKey     = "applied-output"
 	probeStatusesKey     = "probe-statuses"
-	probePeriodKey       = "probe-period"
+	probePeriodKey       = "probe-period-seconds"
 	planKey              = "plan"
 	enqueueAfterDuration = "5s"
 )

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -14,7 +14,7 @@ import (
 )
 
 type HTTPGetAction struct {
-	Path       string `json:"path,omitempty"`
+	URL        string `json:"url,omitempty"`
 	Insecure   bool   `json:"insecure,omitempty"`
 	ClientCert string `json:"clientCert,omitempty"`
 	ClientKey  string `json:"clientKey,omitempty"`
@@ -78,7 +78,7 @@ func DoProbe(probe Probe, probeStatus *ProbeStatus, initial bool) error {
 		k8sProber = k8shttp.NewWithTLSConfig(&tlsConfig, false)
 	}
 
-	probeURL, err := url.Parse(probe.HTTPGetAction.Path)
+	probeURL, err := url.Parse(probe.HTTPGetAction.URL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use URL instead of path for http get action and change probe-period to probe-period-seconds

Signed-off-by: Chris Kim <oats87g@gmail.com>