### PR TITLE
Check K8s cluster is healthy before proceeding to watch for remote K8s plans

### DIFF
--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -56,6 +56,10 @@ func (w *watcher) start(ctx context.Context) {
 		panic(err)
 	}
 
+	if !clientFactory.IsHealthy(ctx) {
+		panic(fmt.Errorf("error while connecting to Kubernetes cluster"))
+	}
+
 	cacheFactory := cache.NewSharedCachedFactory(clientFactory, &cache.SharedCacheFactoryOptions{
 		DefaultNamespace: w.connInfo.Namespace,
 		DefaultTweakList: func(options *metav1.ListOptions) {


### PR DESCRIPTION
https://github.com/rancher/system-agent/issues/33