### PR TITLE
Ensure bin dir always exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -404,7 +404,7 @@ EOF
 }
 
 download_rancher_agent() {
-    mkdir -p ${CATTLE_AGENT_BIN_PREFIX}
+    mkdir -p ${CATTLE_AGENT_BIN_PREFIX}/bin
     if [ "${CATTLE_AGENT_BINARY_LOCAL}" = "true" ]; then
         info "Using local rancher-system-agent binary from ${CATTLE_AGENT_BINARY_LOCAL_LOCATION}"
         cp -f "${CATTLE_AGENT_BINARY_LOCAL_LOCATION}" ${CATTLE_AGENT_BIN_PREFIX}/bin/rancher-system-agent


### PR DESCRIPTION
This is mainly a problem if the /usr partition is read-only and
the bin prefix changes to `/opt/rancher-system-agent`. In any case if we
just always ensure the `bin` directory is created, this should fix #44.