### PR TITLE
Look for proxy environment variables in script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -627,10 +627,15 @@ ensure_systemd_service_stopped() {
 create_env_file() {
     FILE_SA_ENV="/etc/systemd/system/rancher-system-agent.env"
     info "Creating environment file ${FILE_SA_ENV}"
-    UMASK=$(umask)
-    umask 0377
-    env | grep -E -i '^(NO|HTTP|HTTPS)_PROXY' | tee ${FILE_SA_ENV} >/dev/null
-    umask "${UMASK}"
+    install -m 0600 /dev/null "${FILE_SA_ENV}"
+    for i in "HTTP_PROXY" "HTTPS_PROXY" "NO_PROXY"; do
+      eval v=\"\$$i\"
+      if [ -z "${v}" ]; then
+        env | grep -E -i "^${i}" | tee -a ${FILE_SA_ENV} >/dev/null
+      else
+        echo "$i=$v" | tee -a ${FILE_SA_ENV} >/dev/null
+      fi
+    done
 }
 
 do_install() {

--- a/package/suc/run.sh
+++ b/package/suc/run.sh
@@ -36,7 +36,14 @@ fi
 export CATTLE_AGENT_BINARY_LOCAL=true
 export CATTLE_AGENT_BINARY_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent
 if [ -s /host/etc/systemd/system/rancher-system-agent.env ]; then
-  export $(grep -v '^#' /host/etc/systemd/system/rancher-system-agent.env | xargs)
+  for line in $(grep -v '^#' /host/etc/systemd/system/rancher-system-agent.env); do
+    var=${line%%=*}
+    val=${line##*=}
+    eval v=\"\$$var\"
+    if [ -z "$v" ]; then
+      export "$var=$val"
+    fi
+  done
 fi
 chroot /host ${TMPDIR}/install.sh "$@"
 


### PR DESCRIPTION
The install script only looked for proxy environment variables in the
VM's environment. Passing these variables via agent args was not
supported. Therefore, if a user tried to pass proxy variables via agent
args, then the cluster-agent would see them but none of the system-agent
commands would.

Now, if the user passes these variables via agent args (which are
included at the top of the install.sh file), then the install script
will see them and include them in the environment file.

Issue:
https://github.com/rancher/rancher/issues/32633