### PR TITLE
add windows support for root CA cert stores

### DIFF
--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -2,6 +2,7 @@ package prober
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -59,6 +60,7 @@ func DoProbe(probe Probe, probeStatus *ProbeStatus, initial bool) error {
 
 		caCertPool, err := GetSystemCertPool(probe.Name)
 		if err != nil || caCertPool == nil {
+			caCertPool = x509.NewCertPool()
 			logrus.Errorf("error loading system cert pool for probe (%s): %v", probe.Name, err)
 		}
 

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -2,7 +2,6 @@ package prober
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -58,13 +57,13 @@ func DoProbe(probe Probe, probeStatus *ProbeStatus, initial bool) error {
 			tlsConfig.Certificates = []tls.Certificate{clientCert}
 		}
 
-		caCertPool, err := x509.SystemCertPool()
+		caCertPool, err := GetSystemCertPool(probe.Name)
 		if err != nil {
-			caCertPool = x509.NewCertPool()
 			logrus.Errorf("error loading system cert pool for probe (%s): %v", probe.Name, err)
 		}
 
 		if probe.HTTPGetAction.CACert != "" {
+			logrus.Debugf("[DoProbe] adding CA certificate [%s] for probe (%s)", probe.HTTPGetAction.CACert, probe.Name)
 			caCert, err := ioutil.ReadFile(probe.HTTPGetAction.CACert)
 			if err != nil {
 				logrus.Errorf("error loading CA cert for probe (%s) %s: %v", probe.Name, probe.HTTPGetAction.CACert, err)

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -58,7 +58,7 @@ func DoProbe(probe Probe, probeStatus *ProbeStatus, initial bool) error {
 		}
 
 		caCertPool, err := GetSystemCertPool(probe.Name)
-		if err != nil {
+		if err != nil || caCertPool == nil {
 			logrus.Errorf("error loading system cert pool for probe (%s): %v", probe.Name, err)
 		}
 

--- a/pkg/prober/prober_unix.go
+++ b/pkg/prober/prober_unix.go
@@ -5,6 +5,7 @@ package prober
 
 import (
 	"crypto/x509"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/prober/prober_unix.go
+++ b/pkg/prober/prober_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+// +build !windows
+
+package prober
+
+import (
+	"crypto/x509"
+
+	"github.com/sirupsen/logrus"
+)
+
+// GetSystemCertPool returns a x509.CertPool that contains the
+// system certificates if they were present at runtime
+func GetSystemCertPool(probeName string) (*x509.CertPool, error) {
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		caCertPool = x509.NewCertPool()
+		logrus.Errorf("[GetSystemCertPoolUnix] error loading system cert pool for probe (%s): %v", probeName, err)
+	}
+	return caCertPool, nil
+}

--- a/pkg/prober/prober_unix.go
+++ b/pkg/prober/prober_unix.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GetSystemCertPool returns a x509.CertPool that contains the
-// system certificates if they were present at runtime
+// root CA certificates if they are present at runtime
 func GetSystemCertPool(probeName string) (*x509.CertPool, error) {
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {

--- a/pkg/prober/prober_unix.go
+++ b/pkg/prober/prober_unix.go
@@ -17,5 +17,8 @@ func GetSystemCertPool(probeName string) (*x509.CertPool, error) {
 		caCertPool = x509.NewCertPool()
 		logrus.Errorf("[GetSystemCertPoolUnix] error loading system cert pool for probe (%s): %v", probeName, err)
 	}
+	if caCertPool == nil {
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] x509 returned a nil certpool for probe (%s)", probeName)
+	}
 	return caCertPool, nil
 }

--- a/pkg/prober/prober_windows.go
+++ b/pkg/prober/prober_windows.go
@@ -1,0 +1,75 @@
+//go:build windows
+// +build windows
+
+package prober
+
+import (
+	"crypto/x509"
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	CRYPT_E_NOT_FOUND = 0x80092004
+)
+
+// GetSystemCertPool is a workaround to Windows not having x509.SystemCertPool implemented in < go1.18
+// it leverages syscalls to extract system certificates and load them into a new x509.CertPool
+// workaround adapted from: https://github.com/golang/go/issues/16736#issuecomment-540373689
+// ref: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certgetissuercertificatefromstore
+// TODO: Test and remove after system-agent is bumped to go1.18+
+func GetSystemCertPool(probeName string) (*x509.CertPool, error) {
+	logrus.Tracef("[GetSystemCertPoolWindows] building system cert pool for probe (%s)", probeName)
+	root, err := syscall.UTF16PtrFromString("Root")
+	if err != nil {
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to return UTF16 pointer: %v", syscall.GetLastError())
+	}
+	if root == nil {
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] UTF16 pointer for Root returned nil: %v", syscall.GetLastError())
+
+	}
+	storeHandle, err := syscall.CertOpenSystemStore(0, root)
+	if err != nil {
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to open system cert store: %v", syscall.GetLastError())
+	}
+
+	var certs []*x509.Certificate
+	var cert *syscall.CertContext
+
+	cert, err = syscall.CertEnumCertificatesInStore(storeHandle, cert)
+	if err != nil {
+		if errno, ok := err.(syscall.Errno); ok {
+			if errno == CRYPT_E_NOT_FOUND {
+				return nil, fmt.Errorf("[GetSystemCertPoolWindows] no certificate context was found for probe (%s)", probeName)
+			}
+		}
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to enumerate certs in system cert store for probe (%s): %v", probeName, syscall.GetLastError())
+	}
+	if cert == nil {
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] certificate context returned from syscall is nil for probe (%s)", probeName)
+	}
+	// Copy the buf, since ParseCertificate does not create its own copy.
+	buf := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:]
+	buf2 := make([]byte, cert.Length)
+	copy(buf2, buf)
+	c, err := x509.ParseCertificate(buf2)
+	if err != nil {
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to parse x509 certificate for probe (%s): %v", probeName, err)
+	}
+	certs = append(certs, c)
+	logrus.Debugf("[GetSystemCertPoolWindows] Successfully loaded %d certificates from system cert store for probe (%s)", len(certs), probeName)
+
+	caCertPool := x509.NewCertPool()
+	for _, certificate := range certs {
+		if !caCertPool.AppendCertsFromPEM(certificate.RawTBSCertificate) {
+			return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to append cert with CN [%s] to system cert pool for probe (%s)", c.Subject.CommonName, probeName)
+		}
+		logrus.Tracef("[GetSystemCertPoolWindows] successfully appended cert with CN [%s] to system cert pool for probe (%s)", c.Subject.CommonName, probeName)
+	}
+	logrus.Infof("[GetSystemCertPoolWindows] Successfully loaded %d certificates into system cert pool for probe (%s)", len(certs), probeName)
+
+	return caCertPool, nil
+}

--- a/pkg/prober/prober_windows.go
+++ b/pkg/prober/prober_windows.go
@@ -22,7 +22,7 @@ const (
 // ref: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certgetissuercertificatefromstore
 // TODO: Test and remove after system-agent is bumped to go1.18+
 func GetSystemCertPool(probeName string) (*x509.CertPool, error) {
-	logrus.Tracef("[GetSystemCertPoolWindows] building system cert pool for probe (%s)", probeName)
+	logrus.Tracef("[GetSystemCertPoolWindows] building system certContext pool for probe (%s)", probeName)
 	root, err := syscall.UTF16PtrFromString("Root")
 	if err != nil {
 		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to return UTF16 pointer: %v", syscall.GetLastError())
@@ -31,45 +31,78 @@ func GetSystemCertPool(probeName string) (*x509.CertPool, error) {
 		return nil, fmt.Errorf("[GetSystemCertPoolWindows] UTF16 pointer for Root returned nil: %v", syscall.GetLastError())
 
 	}
+	// win32 reference: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certopensystemstorea
+	// If the function succeeds, it returns a handle to the specified certificate store.
 	storeHandle, err := syscall.CertOpenSystemStore(0, root)
 	if err != nil {
-		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to open system cert store: %v", syscall.GetLastError())
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to open system certContext store: %v", syscall.GetLastError())
 	}
 
 	var certs []*x509.Certificate
-	var cert *syscall.CertContext
+	var certContext *syscall.CertContext
 
-	cert, err = syscall.CertEnumCertificatesInStore(storeHandle, cert)
-	if err != nil {
-		if errno, ok := err.(syscall.Errno); ok {
-			if errno == CRYPT_E_NOT_FOUND {
-				return nil, fmt.Errorf("[GetSystemCertPoolWindows] no certificate context was found for probe (%s)", probeName)
+	// ref for why flags value is 0: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certclosestore
+	defer func(store syscall.Handle, flags uint32) {
+		_ = syscall.CertCloseStore(store, flags)
+	}(certContext.Store, 0)
+
+	for {
+		certContext, err = syscall.CertEnumCertificatesInStore(storeHandle, certContext)
+		if err != nil {
+			if errno, ok := err.(syscall.Errno); ok {
+				if errno == CRYPT_E_NOT_FOUND {
+					// the for loop + the syscall for `CertEnumCertificatesInStore` will iterate through
+					// all available certContexts in the specified certificate store and
+					// returns a single certContext containing all certificates in the store
+					// if the error returned here is CRYPTO_E_NOT_FOUND, that indicates no certificates were found.
+					// This happens if the store is empty or if the function reached the end of the store's list.
+					// ref: https://docs.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumcertificatesinstore#return-value
+					logrus.Debugf("[GetSystemCertPoolWindows] no certificates were returned from the root CA store for probe (%s), expected a non-empty return value", probeName)
+					break
+				}
 			}
+			logrus.Errorf("[GetSystemCertPoolWindows] unable to enumerate certs in system certContext store for probe (%s): %v", probeName, syscall.GetLastError())
 		}
-		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to enumerate certs in system cert store for probe (%s): %v", probeName, syscall.GetLastError())
+		if certContext == nil {
+			logrus.Errorf("[GetSystemCertPoolWindows] certificate context returned from syscall is nil for probe (%s)", probeName)
+			break
+		}
+
+		// buf is a ~1048 kilobyte array that serves as a buffer holding the encoded value
+		// for each CA certificate in the Windows root CA store
+		// we use a binary shift to create a ~1048 Kb buffer (slightly larger than 1 megabyte)
+		// [1 << 20]byte -> (1*2)^20 = 1048576 bytes
+		// maximum size of a Windows certificate store is 16 kilobytes and is not related to number of certificates
+		// (1048576*8)/4096 = 2048 (amount of 4096-bit certificates that can be stored)
+		buf := (*[1 << 20]byte)(unsafe.Pointer(certContext.EncodedCert))[:]
+
+		// buf2 is an array of bytes equal to the length of the certContext pointer
+		// which contains a certificate from the Root CA store
+		buf2 := make([]byte, certContext.Length)
+		copy(buf2, buf)
+
+		// validate the root CA certificate and return a x509.Certificate pointer
+		// that is appended into our array of x509 certificates
+		c, err := x509.ParseCertificate(buf2)
+		if err != nil {
+			return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to parse x509 certificate for probe (%s): %v", probeName, err)
+		}
+		certs = append(certs, c)
+		logrus.Debugf("[GetSystemCertPoolWindows] Successfully loaded %d certificates from system certContext store for probe (%s)", len(certs), probeName)
 	}
-	if cert == nil {
-		return nil, fmt.Errorf("[GetSystemCertPoolWindows] certificate context returned from syscall is nil for probe (%s)", probeName)
-	}
-	// Copy the buf, since ParseCertificate does not create its own copy.
-	buf := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:]
-	buf2 := make([]byte, cert.Length)
-	copy(buf2, buf)
-	c, err := x509.ParseCertificate(buf2)
-	if err != nil {
-		return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to parse x509 certificate for probe (%s): %v", probeName, err)
-	}
-	certs = append(certs, c)
-	logrus.Debugf("[GetSystemCertPoolWindows] Successfully loaded %d certificates from system cert store for probe (%s)", len(certs), probeName)
 
 	caCertPool := x509.NewCertPool()
+	if caCertPool == nil {
+		return nil, fmt.Errorf("[GetSystemCertPoolWindows] x509 returned a nil certpool for probe (%s)", probeName)
+	}
+
 	for _, certificate := range certs {
 		if !caCertPool.AppendCertsFromPEM(certificate.RawTBSCertificate) {
-			return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to append cert with CN [%s] to system cert pool for probe (%s)", c.Subject.CommonName, probeName)
+			return nil, fmt.Errorf("[GetSystemCertPoolWindows] unable to append certContext with CN [%s] to system certContext pool for probe (%s)", certificate.Subject.CommonName, probeName)
 		}
-		logrus.Tracef("[GetSystemCertPoolWindows] successfully appended cert with CN [%s] to system cert pool for probe (%s)", c.Subject.CommonName, probeName)
+		logrus.Tracef("[GetSystemCertPoolWindows] successfully appended certContext with CN [%s] to system certContext pool for probe (%s)", certificate.Subject.CommonName, probeName)
 	}
-	logrus.Infof("[GetSystemCertPoolWindows] Successfully loaded %d certificates into system cert pool for probe (%s)", len(certs), probeName)
+	logrus.Infof("[GetSystemCertPoolWindows] Successfully loaded %d certificates into system certContext pool for probe (%s)", len(certs), probeName)
 
 	return caCertPool, nil
 }


### PR DESCRIPTION
### Summary

Move the get/create of a root CA cert store into OS dependent functions

Fixes https://github.com/rancher/system-agent/issues/83
Unblocks https://github.com/rancher/windows/issues/161

### Occurred changes and/or fixed issues

 Windows does not support x509.SystemCertPool() in <go1.18. This PR implements a workaround to load the System Cert Store on Windows nodes.

### Technical notes summary

This is adapted from the following workaround: https://github.com/golang/go/issues/16736#issuecomment-540373689

Error seen on Windows machines:
`Message : error loading system cert pool for probe (kubelet): crypto/x509: system root pool is not available on Windows`

Since <go1.18 on Windows cannot load the root CA cert store, this PR leverages syscalls to load the certificate context from the Root CA cert store and then create a new x509 cert pool that contains the Root CAs. This will likely cause a performance drop on Windows as each probe that requires a CACert will need to build it's own x509 cert pool with the root CAs.

Once system-agent is upgraded to go1.18+ the differing code paths should no longer be required.

### Areas or cases that should be tested

This PR cannot be tested before it is merged as far as I am aware.

### Areas which could experience regressions

These changes should only impact system agent functionality on Windows. The existing functionality for linux hosts has been shuffled into a new function but the underlying code is still the same. For windows, given that loading the CA certs from the root store is currently broken I do not see any potential for regression.

### Screenshot/Video
N/A