### PR TITLE
Reuse version if found for binary, and add uninstall to suc entrypoint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ fi
 #   - CATTLE_AGENT_UNINSTALL_LOCAL (default: false)
 #   - CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION (default: )
 
-FALLBACK=v0.0.1-alpha18
+FALLBACK=v0.2.9
 CACERTS_PATH=cacerts
 RETRYCOUNT=4500
 
@@ -354,14 +354,13 @@ setup_env() {
         fi
 
         if [ -z "${CATTLE_AGENT_UNINSTALL_URL}" ]; then
-            if [ $(curl --connect-timeout 60 --max-time 60 -s https://api.github.com/rate_limit | grep '"rate":' -A 4 | grep '"remaining":' | sed -E 's/.*"[^"]+": (.*),/\1/') = 0 ]; then
+            if [ -n "${VERSION}" ]; then
+                info "Version ${VERSION} used for downloading the rancher-system-agent binary, will reuse for uninstall script"
+            elif [ $(curl --connect-timeout 60 --max-time 60 -s https://api.github.com/rate_limit | grep '"rate":' -A 4 | grep '"remaining":' | sed -E 's/.*"[^"]+": (.*),/\1/') = 0 ]; then
                 info "GitHub Rate Limit exceeded, falling back to known good version"
                 VERSION=$FALLBACK
             else
-              # If VERSION is set by BINARY_URL, just use that
-                if [ -z "$VERSION" ]; then
-                    VERSION=$(curl --connect-timeout 60 --max-time 60 -s "https://api.github.com/repos/rancher/system-agent/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-                fi
+                VERSION=$(curl --connect-timeout 60 --max-time 60 -s "https://api.github.com/repos/rancher/system-agent/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
                 if [ -z "$VERSION" ]; then # Fall back to a known good fallback version because we had an error pulling the latest
                     info "Error contacting GitHub to retrieve the latest version"
                     VERSION=$FALLBACK

--- a/package/suc/run.sh
+++ b/package/suc/run.sh
@@ -14,7 +14,9 @@ cleanup() {
 
 cp /opt/rancher-system-agent-suc/install.sh "/host${TMPDIR}"
 cp /opt/rancher-system-agent-suc/rancher-system-agent "/host${TMPDIR}"
+cp /opt/rancher-system-agent-suc/system-agent-uninstall.sh "/host${TMPDIR}/rancher-system-agent-uninstall.sh"
 chmod +x "/host${TMPDIR}/install.sh"
+chmod +x "/host${TMPDIR}/rancher-system-agent-uninstall.sh"
 
 if [ -n "$SYSTEM_UPGRADE_NODE_NAME" ]; then
     NODE_FILE=/host${TMPDIR}/node.yaml
@@ -34,7 +36,9 @@ if [ -n "$SYSTEM_UPGRADE_NODE_NAME" ]; then
 fi
 
 export CATTLE_AGENT_BINARY_LOCAL=true
+export CATTLE_AGENT_UNINSTALL_LOCAL=true
 export CATTLE_AGENT_BINARY_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent
+export CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent-uninstall.sh
 if [ -s /host/etc/systemd/system/rancher-system-agent.env ]; then
   for line in $(grep -v '^#' /host/etc/systemd/system/rancher-system-agent.env); do
     var=${line%%=*}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/rancher/issues/38438


<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The uninstall script was added to the suc image, but not the script which runs the install script and copies the assets.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added the uninstall script to the script to copy assets.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

I used a QA provisioned airgap setup with a custom suc image with my changed included to test the issue, which worked.

#### Post upgrade

![image](https://user-images.githubusercontent.com/33796120/181355378-620d1123-a257-4b24-a90a-32aa78719bfa.png)

#### Setting used to test

![image](https://user-images.githubusercontent.com/33796120/181355507-51a909c2-4153-46e1-bd1e-e0b45e44ae84.png)

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Upgrade rke2/k3s custom cluster from 1.23 -> 1.24 after this PR has been merged, system-agent has been released, and the version has been bumped in rancher.