### PR TITLE
Add proxy to validate rest config

### DIFF
--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -386,7 +386,8 @@ func validateKC(ctx context.Context, config *rest.Config) error {
 	}
 
 	config.Transport = utilnet.SetTransportDefaults(&http.Transport{
-		DialTLS: func(network, addr string) (net.Conn, error) {
+		Proxy: http.ProxyFromEnvironment,
+		DialTLSContext: func(_ context.Context, network, addr string) (net.Conn, error) {
 			conn, err = tls.Dial(network, addr, tlsConfig)
 			return conn, err
 		},
@@ -403,6 +404,7 @@ func validateKC(ctx context.Context, config *rest.Config) error {
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
+
 	rest, err := rest.UnversionedRESTClientFor(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/39066

A change was made [here](https://github.com/rancher/system-agent/pull/89) to fix TLS on windows. From the text of `utilnet.SetTransportDefaults`:
> // SetTransportDefaults applies the defaults from http.DefaultTransport
// for the Proxy, Dial, and TLSHandshakeTimeout fields if unset

This breaks proxy setups in rancher v2.6.7 and v2.6.8. The following is a version matrix of which system-agent version belongs to which rancher version:
|rancher|system agent|
|---|---|
|v2.6.8|v0.2.10|
|v2.6.7|v0.2.10|
|v2.6.6|v0.2.7|
|v2.6.5|v0.2.7|
|v2.6.4|v0.2.3|
|v2.6.3|v0.1.1|

This has also been tested on Windows, which appears to have other issues, mainly with probes, but it makes it past the system agent install now.