### PR TITLE
Use `kubectl version` to make sure the downloaded binary works

### DIFF
--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -5,7 +5,7 @@ RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \
     curl -L -f -o /usr/bin/kubectl https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/bin/kubectl
-RUN /usr/bin/kubectl version
+RUN /usr/bin/kubectl version --client
 
 ARG ALPINE=alpine:3.16.0
 FROM ${ALPINE}

--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -3,7 +3,7 @@ FROM ${ALPINE} as kubectl
 RUN apk add -U curl
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \
-    curl -L -o /usr/bin/kubectl https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
+    curl -L -f -o /usr/bin/kubectl https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/bin/kubectl
 RUN /usr/bin/kubectl version
 

--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -3,6 +3,7 @@ FROM ${ALPINE} as kubectl
 RUN apk add -U curl
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \
+    if [ "$ARCH" = "aarch64" ]; then ARCH=arm64; fi && \
     curl -L -f -o /usr/bin/kubectl https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/bin/kubectl
 RUN /usr/bin/kubectl version --client

--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -5,6 +5,7 @@ RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \
     curl -L -o /usr/bin/kubectl https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/bin/kubectl
+RUN /usr/bin/kubectl version
 
 ARG ALPINE=alpine:3.16.0
 FROM ${ALPINE}


### PR DESCRIPTION
This fixes an issue where the `kubectl` being downloaded in the image is actually an XML document for a 404 error code. The fix is simply to transform `aarch64` to `arm64` when necessary. Additional protections are added to avoid this issue in the future:
* Use `curl -f` to fail on non 2xx status codes
* Run `kubectl version --client` to make sure the binary works as expected