### PR TITLE
Fix the check_rootfs_rw

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ check_target_ro() {
 
 # check_rootfs_rw returns success if the root filesystem is read-write so we can check for transactional-update system
 check_rootfs_rw() {
-    touch /.rootfs-rw-test && rm -rf /.rootfs-rw-test
+    grep " / " /etc/mtab | grep -q "ro"
     test $? -eq 0
 }
 


### PR DESCRIPTION
Fix #118 

Environment:

```
host1:~ # cat /etc/os-release
NAME="SLE Micro"
VERSION="5.4"
VERSION_ID="5.4"
PRETTY_NAME="SUSE Linux Enterprise Micro 5.4"
ID="sle-micro"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sle-micro:5.4"
```

Small example

```
#!/bin/bash
check_rootfs_rw() {
  grep " / " /etc/mtab | grep -q "ro"
  test $? -eq 0
}


if [ -x /usr/sbin/transactional-update ] && check_rootfs_rw; then
  echo "Detected a transactional-update server"
else
  echo "Using default agent var directory"
fi
```

```
# bash -x prueba
+ '[' -x /usr/sbin/transactional-update ']'
+ check_rootfs_rw
+ grep ' / ' /etc/mtab
+ grep -q ro
+ test 0 -eq 0
+ echo 'Detected a transactional-update server'
Detected a transactional-update server
```