### PR TITLE
Evaluate applied-checksum after setting needApplied flag

### DIFF
--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -8,6 +8,7 @@ Create a file called `config.yaml` in `/etc/rancher/agent` with the contents lik
 workDirectory: /var/lib/rancher/agent/work
 localPlanDirectory: /var/lib/rancher/agent/plans
 remoteEnabled: true
+remoteSkipAlreadyApplied: false
 connectionInfoFile: /etc/rancher/agent/conninfo.yaml
 preserveWorkDirectory: true
 ```

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func run(c *cli.Context) error {
 			return fmt.Errorf("unable to parse connection info file: %w", err)
 		}
 
-		k8splan.Watch(topContext, *applyinator, connInfo)
+		k8splan.Watch(topContext, *applyinator, connInfo, cf.RemoteSkipAlreadyApplied)
 	}
 
 	if cf.LocalEnabled {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ type AgentConfig struct {
 	LocalPlanDir                  string `json:"localPlanDirectory,omitempty"`
 	AppliedPlanDir                string `json:"appliedPlanDirectory,omitempty"`
 	RemoteEnabled                 bool   `json:"remoteEnabled,omitempty"`
+	RemoteSkipAlreadyApplied      bool   `json:"remoteSkipAlreadyApplied,omitempty"`
 	ConnectionInfoFile            string `json:"connectionInfoFile,omitempty"`
 	PreserveWorkDir               bool   `json:"preserveWorkDirectory,omitempty"`
 	ImagesDir                     string `json:"imagesDirectory,omitempty"`

--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -54,10 +54,11 @@ const (
 	cooldownTimerDuration    = "30s"
 )
 
-func Watch(ctx context.Context, applyinator applyinator.Applyinator, connInfo config.ConnectionInfo) {
+func Watch(ctx context.Context, applyinator applyinator.Applyinator, connInfo config.ConnectionInfo, skipAlreadyApplied bool) {
 	w := &watcher{
-		connInfo:    connInfo,
-		applyinator: applyinator,
+		connInfo:           connInfo,
+		applyinator:        applyinator,
+		skipAlreadyApplied: skipAlreadyApplied,
 	}
 
 	go w.start(ctx)
@@ -68,6 +69,7 @@ type watcher struct {
 	applyinator                applyinator.Applyinator
 	lastAppliedResourceVersion string
 	secretUID                  string
+	skipAlreadyApplied         bool
 }
 
 func toInt(resourceVersion string) int {
@@ -198,19 +200,26 @@ func (w *watcher) start(ctx context.Context) {
 			}
 			logrus.Tracef("[K8s] Calculated checksum to be %s", cp.Checksum)
 
-			if !hasRunOnce {
-				logrus.Infof("Detected first start, force-applying one-time instruction set")
-				needsApplied = true
-				hasRunOnce = true
-			}
-
+			alreadyApplied := false
 			if secretChecksumData, ok := secret.Data[appliedChecksumKey]; ok {
 				secretChecksum := string(secretChecksumData)
 				logrus.Tracef("[K8s] Remote plan had an applied checksum value of %s", secretChecksum)
 				if secretChecksum == cp.Checksum {
 					logrus.Debugf("[K8s] Applied checksum was the same as the plan from remote. Not applying.")
 					needsApplied = false
+					alreadyApplied = true
 				}
+			}
+
+			if !hasRunOnce {
+				logrus.Infof("Detected first start, force-applying one-time instruction set")
+				needsApplied = true
+				hasRunOnce = true
+			}
+
+			if w.skipAlreadyApplied && alreadyApplied {
+				logrus.Debugf("[K8s] Skipping already applied plan.")
+				needsApplied = false
 			}
 
 			// Check to see if we've exceeded our failure count threshold


### PR DESCRIPTION
We are running into some issues when the system-agent tries to re-apply remote plans that have been already applied.  

This happens whenever the system-agent is restarted or the entire host is rebooted.  

Some logic is already there to suppress re-execution based on secret resource version: 
```go
			if w.lastAppliedResourceVersion == secret.ResourceVersion && !wasFailedPlan {
				logrus.Debugf("[K8s] last applied resource version (%s) did not change. running probes, skipping apply.", w.lastAppliedResourceVersion)
				needsApplied = false
			}
```

However the `w.lastAppliedResourceVersion` is an in-memory value and a service restart will blank it again.
Therefore evaluating the `applied-checksum` is a more reliable way for remote plans.