### PR TITLE
Add interlocks to ensure operations are not interrupted

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -160,96 +160,96 @@ volumes:
   host:
     path: /var/run/docker.sock
 
----
-kind: pipeline
-name: s390x
-
-platform:
-  os: linux
-  arch: amd64
-
-# Hack needed for s390x: https://gist.github.com/colstrom/c2f359f72658aaabb44150ac20b16d7c#gistcomment-3858388
-node:
-  arch: s390x
-
-steps:
-- name: build
-  image: rancher/dapper:v0.6.0
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: github_binary_release
-  image: rancher/drone-images:github-release-s390x
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    checksum_file: CHECKSUMsum-s390x.txt
-    checksum_flatten: true
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-- name: docker-publish
-  image: rancher/drone-images:docker-s390x
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/system-agent"
-    tag: "${DRONE_TAG}-s390x"
-    username:
-      from_secret: docker_username
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-- name: docker-publish-suc
-  image: rancher/drone-images:docker-s390x
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
-  settings:
-    dockerfile: package/Dockerfile.suc
-    password:
-      from_secret: docker_password
-    repo: "rancher/system-agent"
-    tag: "${DRONE_TAG}-suc-s390x"
-    username:
-      from_secret: docker_username
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
+#---
+#kind: pipeline
+#name: s390x
+#
+#platform:
+#  os: linux
+#  arch: amd64
+#
+## Hack needed for s390x: https://gist.github.com/colstrom/c2f359f72658aaabb44150ac20b16d7c#gistcomment-3858388
+#node:
+#  arch: s390x
+#
+#steps:
+#- name: build
+#  image: rancher/dapper:v0.6.0
+#  commands:
+#  - dapper ci
+#  volumes:
+#  - name: docker
+#    path: /var/run/docker.sock
+#
+#- name: github_binary_release
+#  image: rancher/drone-images:github-release-s390x
+#  settings:
+#    api_key:
+#      from_secret: github_token
+#    prerelease: true
+#    checksum:
+#    - sha256
+#    checksum_file: CHECKSUMsum-s390x.txt
+#    checksum_flatten: true
+#    files:
+#    - "dist/artifacts/*"
+#  when:
+#    instance:
+#    - drone-publish.rancher.io
+#    ref:
+#    - refs/head/master
+#    - refs/tags/*
+#    event:
+#    - tag
+#
+#- name: docker-publish
+#  image: rancher/drone-images:docker-s390x
+#  volumes:
+#    - name: docker
+#      path: /var/run/docker.sock
+#  settings:
+#    dockerfile: package/Dockerfile
+#    password:
+#      from_secret: docker_password
+#    repo: "rancher/system-agent"
+#    tag: "${DRONE_TAG}-s390x"
+#    username:
+#      from_secret: docker_username
+#  when:
+#    instance:
+#    - drone-publish.rancher.io
+#    ref:
+#    - refs/head/master
+#    - refs/tags/*
+#    event:
+#    - tag
+#
+#- name: docker-publish-suc
+#  image: rancher/drone-images:docker-s390x
+#  volumes:
+#    - name: docker
+#      path: /var/run/docker.sock
+#  settings:
+#    dockerfile: package/Dockerfile.suc
+#    password:
+#      from_secret: docker_password
+#    repo: "rancher/system-agent"
+#    tag: "${DRONE_TAG}-suc-s390x"
+#    username:
+#      from_secret: docker_username
+#  when:
+#    instance:
+#    - drone-publish.rancher.io
+#    ref:
+#    - refs/head/master
+#    - refs/tags/*
+#    event:
+#    - tag
+#
+#volumes:
+#- name: docker
+#  host:
+#    path: /var/run/docker.sock
 
 ---
 kind: pipeline
@@ -270,7 +270,7 @@ steps:
     platforms:
       - linux/amd64
       - linux/arm64
-      - linux/s390x
+#      - linux/s390x
     target: "rancher/system-agent:${DRONE_TAG}"
     template: "rancher/system-agent:${DRONE_TAG}-ARCH"
   when:
@@ -285,7 +285,7 @@ steps:
 depends_on:
 - amd64
 - arm64
-- s390x
+#- s390x
 
 ---
 kind: pipeline
@@ -306,7 +306,7 @@ steps:
     platforms:
       - linux/amd64
       - linux/arm64
-      - linux/s390x
+#      - linux/s390x
     target: "rancher/system-agent:${DRONE_TAG}-suc"
     template: "rancher/system-agent:${DRONE_TAG}-suc-ARCH"
   when:
@@ -321,4 +321,4 @@ steps:
 depends_on:
 - amd64
 - arm64
-- s390x
+#- s390x

--- a/install.sh
+++ b/install.sh
@@ -428,6 +428,7 @@ setup_env() {
 
 ensure_directories() {
     mkdir -p ${CATTLE_AGENT_VAR_DIR}/interlock
+    mkdir -p ${CATTLE_AGENT_CONFIG_DIR}
     chmod 700 ${CATTLE_AGENT_VAR_DIR}
     chmod 700 ${CATTLE_AGENT_VAR_DIR}/interlock
     chmod 700 ${CATTLE_AGENT_CONFIG_DIR}
@@ -799,6 +800,9 @@ generate_cattle_identifier() {
         info "Generating Cattle ID"
         if [ -f "${CATTLE_AGENT_CONFIG_DIR}/cattle-id" ]; then
             CATTLE_ID=$(cat ${CATTLE_AGENT_CONFIG_DIR}/cattle-id);
+            if [ -z "${CATTLE_ID}" ]; then
+              fatal "Cattle ID was empty, aborting installation"
+            fi
             info "Cattle ID was already detected as ${CATTLE_ID}. Not generating a new one."
             return
         fi
@@ -808,6 +812,9 @@ generate_cattle_identifier() {
         umask 0177
         echo "${CATTLE_ID}" > ${CATTLE_AGENT_CONFIG_DIR}/cattle-id
         umask "${UMASK}"
+        if [ ! -s ${CATTLE_AGENT_CONFIG_DIR}/cattle-id ]; then
+          fatal "Cattle ID could not be persisted. Aborting installation"
+        fi
         return
     fi
     info "Not generating Cattle ID"

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ fi
 FALLBACK=v0.2.9
 CACERTS_PATH=cacerts
 RETRYCOUNT=4500
-APPLYINATOR_ACTIVE_WAIT_COUNT=60
+APPLYINATOR_ACTIVE_WAIT_COUNT=60 # If the system-agent is unhealthy but had created an interlock file to indicate it was actively applying a plan, after 5 minutes, ignore the interlock.
 
 # info logs the given argument at info log level.
 info() {

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func run(c *cli.Context) error {
 	logrus.Infof("Using directory %s for work", cf.WorkDir)
 
 	imageUtil := image.NewUtility(cf.ImagesDir, cf.ImageCredentialProviderConfig, cf.ImageCredentialProviderBinDir, cf.AgentRegistriesFile)
-	applyinator := applyinator.NewApplyinator(cf.WorkDir, cf.PreserveWorkDir, cf.AppliedPlanDir, imageUtil)
+	applyinator := applyinator.NewApplyinator(cf.WorkDir, cf.PreserveWorkDir, cf.AppliedPlanDir, cf.InterlockDir, imageUtil)
 
 	if cf.RemoteEnabled {
 		logrus.Infof("Starting remote watch of plans")

--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -177,28 +177,26 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 			fileContents, err := os.ReadFile(restartPendingInterlockFilePath)
 			if err != nil {
 				return output, fmt.Errorf("unable to read restart pending interlock file %s: %w", restartPendingInterlockFile, err)
-			} else {
-				if len(fileContents) == 0 {
-					// Write "now" as the first observed time of the file.
-					if err := os.WriteFile(restartPendingInterlockFile, []byte(nowUnixTimeString), 0600); err != nil {
-						return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFile, err)
-					}
-					return output, fmt.Errorf("restart is pending for system-agent")
-				} else {
-					// Parse the time out of the file and determine if we have passed our time threshold
-					t, err := time.Parse(time.UnixDate, string(fileContents))
-					if err != nil {
-						return output, fmt.Errorf("unable to parse first-observed time in restart pending interlock file %s: %w", restartPendingInterlockFile, err)
-					}
-					if now.Before(t.Add(restartPendingTimeout)) {
-						return output, fmt.Errorf("restart is pending for system-agent")
-					}
-					// remove the restart pending file
-					err = os.Remove(restartPendingInterlockFile)
-					if err != nil {
-						logrus.Errorf("error encountered while removing restart pending interlock file %s: %v", restartPendingInterlockFilePath, err)
-					}
+			}
+			if len(fileContents) == 0 {
+				// Write "now" as the first observed time of the file.
+				if err := os.WriteFile(restartPendingInterlockFile, []byte(nowUnixTimeString), 0600); err != nil {
+					return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFile, err)
 				}
+				return output, fmt.Errorf("restart is pending for system-agent")
+			}
+			// Parse the time out of the file and determine if we have passed our time threshold
+			t, err := time.Parse(time.UnixDate, string(fileContents))
+			if err != nil {
+				return output, fmt.Errorf("unable to parse first-observed time in restart pending interlock file %s: %w", restartPendingInterlockFile, err)
+			}
+			if now.Before(t.Add(restartPendingTimeout)) {
+				return output, fmt.Errorf("restart is pending for system-agent")
+			}
+			// remove the restart pending file
+			err = os.Remove(restartPendingInterlockFile)
+			if err != nil {
+				logrus.Errorf("error encountered while removing restart pending interlock file %s: %v", restartPendingInterlockFilePath, err)
 			}
 		}
 

--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -176,14 +176,14 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 			// check the restart pending interlock file to see if we've passed our threshold for blocking
 			fileContents, err := os.ReadFile(restartPendingInterlockFilePath)
 			if err != nil {
-				return output, fmt.Errorf("unable to read restart pending interlock file %s: %w", restartPendingInterlockFile, err)
+				return output, fmt.Errorf("unable to read restart pending interlock file %s: %w", restartPendingInterlockFilePath, err)
 			}
 			// Parse the time out of the file and determine if we have passed our time threshold
 			t, err := time.Parse(time.UnixDate, string(fileContents))
 			if err != nil {
 				// If we are unable to parse the first observed time out of the file, write "now" as the first observed time of the file.
-				if err := os.WriteFile(restartPendingInterlockFile, []byte(nowUnixTimeString), 0600); err != nil {
-					return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFile, err)
+				if err := os.WriteFile(restartPendingInterlockFilePath, []byte(nowUnixTimeString), 0600); err != nil {
+					return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFilePath, err)
 				}
 				return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", restartPendingTimeout.String())
 			}
@@ -191,7 +191,7 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 				return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", t.Add(restartPendingTimeout).Sub(now).String())
 			}
 			// remove the restart pending file
-			err = os.Remove(restartPendingInterlockFile)
+			err = os.Remove(restartPendingInterlockFilePath)
 			if err != nil {
 				logrus.Errorf("error encountered while removing restart pending interlock file %s: %v", restartPendingInterlockFilePath, err)
 			}

--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -178,20 +178,17 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 			if err != nil {
 				return output, fmt.Errorf("unable to read restart pending interlock file %s: %w", restartPendingInterlockFile, err)
 			}
-			if len(fileContents) == 0 {
-				// Write "now" as the first observed time of the file.
-				if err := os.WriteFile(restartPendingInterlockFile, []byte(nowUnixTimeString), 0600); err != nil {
-					return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFile, err)
-				}
-				return output, fmt.Errorf("restart is pending for system-agent")
-			}
 			// Parse the time out of the file and determine if we have passed our time threshold
 			t, err := time.Parse(time.UnixDate, string(fileContents))
 			if err != nil {
-				return output, fmt.Errorf("unable to parse first-observed time in restart pending interlock file %s: %w", restartPendingInterlockFile, err)
+				// If we are unable to parse the first observed time out of the file, write "now" as the first observed time of the file.
+				if err := os.WriteFile(restartPendingInterlockFile, []byte(nowUnixTimeString), 0600); err != nil {
+					return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFile, err)
+				}
+				return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", restartPendingTimeout.String())
 			}
 			if now.Before(t.Add(restartPendingTimeout)) {
-				return output, fmt.Errorf("restart is pending for system-agent")
+				return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", t.Add(restartPendingTimeout).Sub(now).String())
 			}
 			// remove the restart pending file
 			err = os.Remove(restartPendingInterlockFile)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type AgentConfig struct {
 	AgentRegistriesFile           string `json:"agentRegistriesFile,omitempty"`
 	ImageCredentialProviderConfig string `json:"imageCredentialProviderConfig,omitempty"`
 	ImageCredentialProviderBinDir string `json:"imageCredentialProviderBinDirectory,omitempty"`
+	InterlockDir                  string `json:"interlockDirectory,omitempty"`
 }
 
 type ConnectionInfo struct {

--- a/scripts/version
+++ b/scripts/version
@@ -6,7 +6,7 @@ fi
 
 COMMIT=$(git rev-parse --short HEAD)
 GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
-CROSS=true
+CROSS=${CROSS:-true}
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 else


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/43658

This PR adds interlocks to the system-agent which are used to indicate whether the install script and applyinator should continue.

The first interlock `restart-pending` indicates to the system-agent that a restart is pending per the install script, and disallows the applyinator from starting to apply a plan when a restart is pending.

The second interlock `applyinator-active` indicates to the install script that the applyinator is currently reconciling a plan and should not restart the system-agent.

The `restart-pending` interlock has a timeout feature built into the system-agent which allows the system-agent to ignore the pending restart after 5 minutes, which can be the case when the install script quits prematurely.