### PR TITLE
Cleanup and exit if cannot download valid connection info.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -774,7 +774,7 @@ retrieve_connection_info() {
                 ;;
             esac
         done
-        error "Max retries exceeded for downloading Rancher connection information."
+        error "Failed to download Rancher connection information in ${i} attempts"
         umask "${UMASK}"
         # Clean up invalid rancher2_connection_info.json file
         rm -f ${CATTLE_AGENT_VAR_DIR}/rancher2_connection_info.json
@@ -887,7 +887,7 @@ do_install() {
 
     if [ -n "${CATTLE_TOKEN}" ]; then
         generate_cattle_identifier
-        retrieve_connection_info || fatal "Could not get connection_info before max retries" # Only retrieve connection information from Rancher if a token was passed in.
+        retrieve_connection_info || fatal "Aborting system-agent installation due to failure to retrieve Rancher connection information"
     fi
     create_systemd_service_file
     create_env_file

--- a/install.sh
+++ b/install.sh
@@ -763,7 +763,8 @@ retrieve_connection_info() {
             case "${RESPONSE}" in
             200)
                 info "Successfully downloaded Rancher connection information"
-                break
+                umask "${UMASK}"
+                return 0
                 ;;
             *)
                 i=$((i + 1))
@@ -773,7 +774,11 @@ retrieve_connection_info() {
                 ;;
             esac
         done
+        error "Max retries exceeded for downloading Rancher connection information."
         umask "${UMASK}"
+        # Clean up invalid rancher2_connection_info.json file
+        rm -f ${CATTLE_AGENT_VAR_DIR}/rancher2_connection_info.json
+        return 1
     fi
 }
 
@@ -882,7 +887,7 @@ do_install() {
 
     if [ -n "${CATTLE_TOKEN}" ]; then
         generate_cattle_identifier
-        retrieve_connection_info # Only retrieve connection information from Rancher if a token was passed in.
+        retrieve_connection_info || fatal "Could not get connection_info before max retries" # Only retrieve connection information from Rancher if a token was passed in.
     fi
     create_systemd_service_file
     create_env_file


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/43991

This PR fixes an issue where if maximum retries are met attempting to download the rancher2_connection_info.json, the script continues with invalid data in that file causing the rancher-system-agent to fail to start.  This change cleans up the errant json file and exits the installer instead of continuing to setup a service doomed for failure.

Ref. SUSE Support case #01054437