### PR TITLE
Change base images to `bci-micro`

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,9 +1,11 @@
-FROM golang:1.22-alpine3.20
+FROM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
+RUN zypper -n rm container-suseconnect && \
+    zypper -n install curl docker gzip tar wget awk zip
+
 RUN go install golang.org/x/lint/golint@latest && \
     go install golang.org/x/tools/cmd/goimports@latest && \
     rm -rf /go/src /go/pkg

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM registry.suse.com/bci/bci-micro:15.6
 COPY bin/rancher-system-agent /usr/bin/
 RUN chmod +x /usr/bin/rancher-system-agent
 CMD ["rancher-system-agent"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,7 @@
 FROM registry.suse.com/bci/bci-micro:15.6
+
+RUN zypper in -y openssl patterns-base-fips
+
 COPY bin/rancher-system-agent /usr/bin/
 RUN chmod +x /usr/bin/rancher-system-agent
 CMD ["rancher-system-agent"]

--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -1,20 +1,29 @@
-ARG ALPINE=alpine:3.18
-FROM ${ALPINE} as kubectl
-ENV KUBECTL_VERSION v1.29.7
-RUN apk add -U curl
+ARG IMG_VERSION=15.6
+FROM registry.suse.com/bci/bci-base:${IMG_VERSION} as kubectl
+
+ARG KUBECTL_VERSION=v1.29.7
+
+# https://dl.k8s.io/release/v1.29.7/bin/linux/arm64/kubectl.sha256
+ENV KUBECTL_SUM_arm64=7b6649aaa298be728c5fb7ccb65f98738a4e8bda0741afbd5a9ed9e488c0e725
+# https://dl.k8s.io/release/v1.29.7/bin/linux/amd64/kubectl.sha256
+ENV KUBECTL_SUM_amd64=e3df008ef60ea50286ea93c3c40a020e178a338cea64a185b4e21792d88c75d6
+
+RUN zypper in -y curl
+
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \
     if [ "$ARCH" = "aarch64" ]; then ARCH=arm64; fi && \
-    curl -L -f -o /usr/bin/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && \
-    chmod +x /usr/bin/kubectl
+    curl -L -f -o kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/bin/kubectl && \
+    KUBECTL_SUM="KUBECTL_SUM_${ARCH}" && echo "${!KUBECTL_SUM}  /usr/bin/kubectl" | sha256sum -c -
 RUN /usr/bin/kubectl version --client
 
-ARG ALPINE=alpine:3.18
-FROM ${ALPINE}
+FROM registry.suse.com/bci/bci-micro:${IMG_VERSION}
 
 ENV CATTLE_AGENT_VAR_DIR="/var/lib/rancher/agent"
 
 RUN mkdir /opt/rancher-system-agent-suc
+
 COPY install.sh /opt/rancher-system-agent-suc/install.sh
 COPY system-agent-uninstall.sh /opt/rancher-system-agent-suc/system-agent-uninstall.sh
 COPY bin/rancher-system-agent /opt/rancher-system-agent-suc

--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -8,7 +8,7 @@ ENV KUBECTL_SUM_arm64=7b6649aaa298be728c5fb7ccb65f98738a4e8bda0741afbd5a9ed9e488
 # https://dl.k8s.io/release/v1.29.7/bin/linux/amd64/kubectl.sha256
 ENV KUBECTL_SUM_amd64=e3df008ef60ea50286ea93c3c40a020e178a338cea64a185b4e21792d88c75d6
 
-RUN zypper in -y curl
+RUN zypper in -y curl openssl patterns-base-fips
 
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \


### PR DESCRIPTION

Issues:
* https://github.com/rancher/rancher/issues/46098
* https://github.com/rancher/rancher/issues/46621
* https://github.com/rancher/rancher/issues/46623

~Note that `kubectl` is also being bumped to `v1.28.10` as the previously used `v1.27` is EOL.~ - already bumped in another PR