### PR TITLE
Version bump for Alpine and Kubectl

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.18.3
+FROM alpine:3.18
 COPY bin/rancher-system-agent /usr/bin/
 CMD ["rancher-system-agent"]

--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -1,14 +1,15 @@
-ARG ALPINE=alpine:3.18.3
+ARG ALPINE=alpine:3.18
 FROM ${ALPINE} as kubectl
+ENV KUBECTL_VERSION v1.27.10
 RUN apk add -U curl
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \
     if [ "$ARCH" = "aarch64" ]; then ARCH=arm64; fi && \
-    curl -L -f -o /usr/bin/kubectl https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
+    curl -L -f -o /usr/bin/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x /usr/bin/kubectl
 RUN /usr/bin/kubectl version --client
 
-ARG ALPINE=alpine:3.18.3
+ARG ALPINE=alpine:3.18
 FROM ${ALPINE}
 
 RUN mkdir /opt/rancher-system-agent-suc


### PR DESCRIPTION
Version bump for Alpine and Kubectl:
- Alpine - `3.18.3` -> `3.18`
- Kubectl - `v1.24.0` -> `v1.27.10` (match the current K8s version in `go.mod`)