### PR TITLE
[Followup] Change base images to `bci-micro`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,22 @@
-FROM registry.suse.com/bci/bci-micro:15.6
+FROM registry.suse.com/bci/bci-micro:15.6 AS final
 
-RUN zypper in -y openssl patterns-base-fips
+# Temporary build stage image
+FROM registry.suse.com/bci/bci-base:15.6 AS builder
+
+# Install system packages using builder image that has zypper
+COPY --from=final / /chroot/
+
+RUN zypper refresh && \
+    zypper --installroot /chroot -n in --no-recommends \
+    openssl patterns-base-fips && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
+
+# Main stage using bci-micro as the base image
+FROM final
+
+# Copy binaries and configuration files from builder to micro
+COPY --from=builder /chroot/ /
 
 COPY bin/rancher-system-agent /usr/bin/
 RUN chmod +x /usr/bin/rancher-system-agent


### PR DESCRIPTION
Follow up to https://github.com/rancher/system-agent/pull/169 as the images would not build due to the lack of `zypper` in the `bci-micro` image