### PR TITLE
[Followup 2] Change base images to `bci-micro`

### DIFF
--- a/package/Dockerfile.suc
+++ b/package/Dockerfile.suc
@@ -1,5 +1,18 @@
 ARG IMG_VERSION=15.6
-FROM registry.suse.com/bci/bci-base:${IMG_VERSION} as kubectl
+
+FROM registry.suse.com/bci/bci-micro:${IMG_VERSION} AS final
+
+# Temporary build stage image
+FROM registry.suse.com/bci/bci-base:${IMG_VERSION} AS builder
+
+# Install system packages using builder image that has zypper
+COPY --from=final / /chroot/
+
+RUN zypper refresh && \
+    zypper --installroot /chroot -n in --no-recommends \
+    openssl patterns-base-fips grep && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/tmp/* /chroot/var/tmp/* /chroot/usr/share/doc/packages/*
 
 ARG KUBECTL_VERSION=v1.29.7
 
@@ -14,11 +27,15 @@ RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH=amd64; fi && \
     if [ "$ARCH" = "aarch64" ]; then ARCH=arm64; fi && \
     curl -L -f -o kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/bin/kubectl && \
-    KUBECTL_SUM="KUBECTL_SUM_${ARCH}" && echo "${!KUBECTL_SUM}  /usr/bin/kubectl" | sha256sum -c -
-RUN /usr/bin/kubectl version --client
+    install -o root -g root -m 0755 kubectl /chroot/usr/bin/kubectl && \
+    KUBECTL_SUM="KUBECTL_SUM_${ARCH}" && echo "${!KUBECTL_SUM}  /chroot/usr/bin/kubectl" | sha256sum -c -
+RUN /chroot/usr/bin/kubectl version --client
 
-FROM registry.suse.com/bci/bci-micro:${IMG_VERSION}
+# Main stage using bci-micro as the base image
+FROM final
+
+# Copy binaries and configuration files from builder to micro
+COPY --from=builder /chroot/ /
 
 ENV CATTLE_AGENT_VAR_DIR="/var/lib/rancher/agent"
 
@@ -28,7 +45,6 @@ COPY install.sh /opt/rancher-system-agent-suc/install.sh
 COPY system-agent-uninstall.sh /opt/rancher-system-agent-suc/system-agent-uninstall.sh
 COPY bin/rancher-system-agent /opt/rancher-system-agent-suc
 COPY package/suc/run.sh /opt/rancher-system-agent-suc/run.sh
-COPY --from=kubectl /usr/bin/kubectl /usr/bin/
 RUN chmod +x /opt/rancher-system-agent-suc/rancher-system-agent
 
 ENTRYPOINT ["/opt/rancher-system-agent-suc/run.sh"]


### PR DESCRIPTION
Follow up to https://github.com/rancher/system-agent/pull/169 and https://github.com/rancher/system-agent/pull/194 as the SUC image was erroring out