### PR TITLE
Update Windows Files

### DIFF
--- a/.github/workflows/ci-on-pull-request.yaml
+++ b/.github/workflows/ci-on-pull-request.yaml
@@ -33,3 +33,30 @@ jobs:
 
       - name: build with Dapper
         run: dapper gha-ci
+
+  test-build-windows:
+    strategy:
+      matrix:
+        os: [ windows ]
+        platform: [ windows-2019, windows-latest ]
+        arch: [ amd64 ]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+
+      - name: Set environment variables
+        run: |
+          echo "DAPPER_HOST_ARCH=${{ matrix.arch }}"   >> "$GITHUB_ENV"
+          echo "GH_VERSION=${{ github.ref_name }}"     >> "$GITHUB_ENV"
+          echo "GOARCH=${{ matrix.arch }}"             >> "$GITHUB_ENV"
+          echo "GOOS=${{ matrix.os }}"                 >> "$GITHUB_ENV"
+          echo "CROSS=false"                           >> "$GITHUB_ENV"
+
+      - name: Build and Test
+        run: bash ./scripts/gha-ci

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29
+	github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065
 	github.com/rancher/wharfie v0.6.6
 	github.com/rancher/wrangler v1.1.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/rancher/dynamiclistener v0.3.5 h1:5TaIHvkDGmZKvc96Huur16zfTKOiLhDtK4S
 github.com/rancher/dynamiclistener v0.3.5/go.mod h1:dW/YF6/m2+uEyJ5VtEcd9THxda599HP6N9dSXk81+k0=
 github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29 h1:+kige/h8/LnzWgPjB5NUIHz/pWiW/lFpqcTUkN5uulY=
 github.com/rancher/lasso v0.0.0-20230830164424-d684fdeb6f29/go.mod h1:kgk9kJVMj9FIrrXU0iyM6u/9Je4bEjPImqswkTVaKsQ=
+github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065 h1:nJPrW/DdnSYQnKryQYlFXMs6nh12Q7MCW8Zb6l9Cb1A=
+github.com/rancher/permissions v0.0.0-20240924180251-69b0dcb34065/go.mod h1:PDAb+l6/i6cbSokQ2CuNCgGOT/BHQY2WgZATwPXEyU4=
 github.com/rancher/wharfie v0.6.6 h1:ESxPxBDiq9RXd8G9fC71qc7+AbetThVtxPC9K8VVZ2Y=
 github.com/rancher/wharfie v0.6.6/go.mod h1:sfCy07HF8EE1MDKhpDc/cLptLTiTC0y/wisD44gr8uc=
 github.com/rancher/wrangler v1.1.1 h1:wmqUwqc2M7ADfXnBCJTFkTB5ZREWpD78rnZMzmxwMvM=

--- a/pkg/applyinator/file_test.go
+++ b/pkg/applyinator/file_test.go
@@ -1,0 +1,300 @@
+//go:build !arm64
+
+package applyinator
+
+import (
+	"encoding/base64"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestWriteContentToFile(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	getFile := func(path string, permissions string, content string) File {
+		return File{
+			Permissions: permissions,
+			Path:        filepath.Join(tempDir, path),
+			Content:     content,
+		}
+	}
+
+	testCases := []struct {
+		Path        string
+		Permissions string
+		Content     string
+
+		Base64Encode bool
+
+		ExpectedPermissions os.FileMode
+		ExpectedErr         bool
+	}{
+		{
+			Path:    "test-no-perms",
+			Content: "hello world",
+
+			ExpectedPermissions: defaultFilePermissions,
+			ExpectedErr:         false,
+		},
+		{
+			Path:        "test-perms",
+			Permissions: "0666",
+			Content:     "hello world 2",
+
+			ExpectedPermissions: 0666,
+			ExpectedErr:         false,
+		},
+		{
+			Path:    "test-invalid-base64",
+			Content: "not base64 content",
+
+			Base64Encode: true,
+
+			ExpectedErr: true,
+		},
+		{
+			Path:    "test-no-perms-base64",
+			Content: "aGVsbG8gd29ybGQ=",
+
+			Base64Encode: true,
+
+			ExpectedPermissions: defaultFilePermissions,
+			ExpectedErr:         false,
+		},
+		{
+			Path:        "test-perms-base64",
+			Permissions: "0666",
+			Content:     "aGVsbG8gd29ybGQ=",
+
+			Base64Encode: true,
+
+			ExpectedPermissions: 0666,
+			ExpectedErr:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Path, func(t *testing.T) {
+			f := getFile(tc.Path, tc.Permissions, tc.Content)
+			t.Run("Create File", func(t *testing.T) {
+				var err error
+				if tc.Base64Encode {
+					err = writeBase64ContentToFile(f)
+				} else {
+					var perms os.FileMode
+					perms, err = parsePerm(f.Permissions)
+					if err != nil && f.Permissions != "" {
+						t.Fatalf("invalid permissions provided: %s", f.Permissions)
+					}
+					err = writeContentToFile(f.Path, f.UID, f.GID, perms, []byte(f.Content))
+				}
+				if tc.ExpectedErr {
+					if err == nil {
+						t.Error("expected error, returned successfully")
+					}
+					return
+				}
+				if err != nil {
+					t.Error(err)
+					return
+				}
+			})
+			if tc.ExpectedErr {
+				// no need to run any further tests if file was never created
+				return
+			}
+			t.Run("Read File", func(t *testing.T) {
+				content, err := os.ReadFile(f.Path)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				decoded := []byte(tc.Content)
+				if tc.Base64Encode {
+					decoded, err = base64.StdEncoding.DecodeString(tc.Content)
+					if err != nil {
+						t.Error(err)
+						return
+					}
+				}
+
+				if !reflect.DeepEqual(content, decoded) {
+					t.Errorf("expected %s, found %s", tc.Content, content)
+					return
+				}
+			})
+			t.Run("Check Permissions", func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					t.Skip("cannot get permissions on Windows")
+				}
+				permissions, err := getPermissions(f.Path)
+				if err != nil {
+					t.Error(err)
+				}
+				if permissions != tc.ExpectedPermissions {
+					t.Errorf("expected permissions %v, found %v", tc.ExpectedPermissions, permissions)
+				}
+			})
+		})
+	}
+}
+
+func TestCreateDirectory(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	getFile := func(path string, permissions string) File {
+		return File{
+			Directory:   true,
+			Permissions: permissions,
+			Path:        filepath.Join(tempDir, path),
+		}
+	}
+
+	testCases := []struct {
+		Path        string
+		Permissions string
+
+		ExpectedPermissions os.FileMode
+		ExpectedErr         bool
+	}{
+		{
+			Path: "test-no-perms",
+
+			ExpectedPermissions: fs.ModeDir | defaultDirectoryPermissions,
+			ExpectedErr:         false,
+		},
+		{
+			Path:        "test-perms",
+			Permissions: "0777",
+
+			ExpectedPermissions: fs.ModeDir | 0777,
+			ExpectedErr:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Path, func(t *testing.T) {
+			f := getFile(tc.Path, tc.Permissions)
+			t.Run("Create Directory", func(t *testing.T) {
+				err := createDirectory(f)
+				if tc.ExpectedErr {
+					if err == nil {
+						t.Error("expected error, returned successfully")
+					}
+					return
+				}
+				if err != nil {
+					t.Error(err)
+				}
+			})
+			t.Run("Check Permissions", func(t *testing.T) {
+				if runtime.GOOS == "windows" {
+					t.Skip("cannot get permissions on Windows")
+				}
+				permissions, err := getPermissions(f.Path)
+				if err != nil {
+					t.Error(err)
+				}
+				if permissions != tc.ExpectedPermissions {
+					t.Errorf("expected permissions %v, found %v", tc.ExpectedPermissions, permissions)
+				}
+			})
+		})
+	}
+}
+
+func TestParsePerm(t *testing.T) {
+	testCases := []struct {
+		Permissions string
+
+		ExpectedPermissions os.FileMode
+		ExpectedErr         bool
+	}{
+		{
+			Permissions: "0777",
+
+			ExpectedPermissions: 0777,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "0007",
+
+			ExpectedPermissions: 0007,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "0070",
+
+			ExpectedPermissions: 0070,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "0700",
+
+			ExpectedPermissions: 0700,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "0333",
+
+			ExpectedPermissions: 0333,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "0003",
+
+			ExpectedPermissions: 0003,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "0030",
+
+			ExpectedPermissions: 0030,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "0300",
+
+			ExpectedPermissions: 0300,
+			ExpectedErr:         false,
+		},
+		{
+			Permissions: "",
+			ExpectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		testName := tc.Permissions
+		if len(testName) == 0 {
+			testName = "Empty String"
+		}
+		t.Run(testName, func(t *testing.T) {
+			fileMode, err := parsePerm(tc.Permissions)
+			if tc.ExpectedErr {
+				if err == nil {
+					t.Error("expected error, returned successfully")
+				}
+				return
+			}
+			if err != nil {
+				t.Error(err)
+			}
+			if fileMode != tc.ExpectedPermissions {
+				t.Errorf("expected filemode %v, found %v", tc.ExpectedPermissions, fileMode)
+			}
+		})
+	}
+}

--- a/pkg/applyinator/file_unix.go
+++ b/pkg/applyinator/file_unix.go
@@ -17,3 +17,11 @@ func reconcileFilePermissions(path string, uid int, gid int, perm os.FileMode) e
 	}
 	return os.Chown(path, uid, gid)
 }
+
+func getPermissions(path string) (os.FileMode, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return 0000, err
+	}
+	return fileInfo.Mode(), nil
+}

--- a/pkg/applyinator/file_unix.go
+++ b/pkg/applyinator/file_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package applyinator
 

--- a/pkg/applyinator/file_windows.go
+++ b/pkg/applyinator/file_windows.go
@@ -4,13 +4,25 @@
 package applyinator
 
 import (
-	"os"
-
+	"github.com/rancher/permissions/pkg/acl"
 	"github.com/sirupsen/logrus"
+
+	"os"
 )
 
 // reconcileFilePermissions abstracts out the file permissions checks and are a no op on Windows
 func reconcileFilePermissions(path string, uid int, gid int, perm os.FileMode) error {
-	logrus.Debugf("windows file permissions for %s will not be reconciled to %d:%d %d", path, uid, gid, perm)
-	return nil
+	logrus.Debugf("[Applyinator] Reconciling file permissions for %s to %d", path, perm)
+	if uid != 0 || gid != 0 {
+		// note: although acl.Chown is implemented, adding support for Windows UID and GIDs (which are strings)
+		// would require adding new fields to the File struct.
+		logrus.Debugf("windows file permissions do not support custom uid and guid (%d:%d) for %s", uid, gid, path)
+	}
+
+	return acl.Chmod(path, perm)
+}
+
+func getPermissions(path string) (os.FileMode, error) {
+	logrus.Debugf("getting windows file permissions for %s is not implemented", path)
+	return 0000, nil
 }

--- a/pkg/applyinator/file_windows.go
+++ b/pkg/applyinator/file_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package applyinator
 


### PR DESCRIPTION
This PR closes the gap between how files are created on Linux and Windows. It also adds unit tests around file permissions, as well as updates CI to run these tests on both Linux and Windows. 

Note: This unit test does not compile properly on arm, and I can't determine why. Testing the CI on my fork repeatedly resulted in the below error. Because of this, I added a build tag to exclude this unit test on arm. I'm not aware of any differences between file creation and permissions between the two architectures, but if we feel strongly about including this test on arm I can continue to look into the error. But ultimately, for linux, this unit test is covering functionality was added to this repo ~3 years ago.

```  
fork/exec /tmp/go-build3394345592/b1239/applyinator.test: exec format error
FAIL	github.com/rancher/system-agent/pkg/applyinator	0.002s
```