### PR TITLE
Add ResetFailureCountOnServiceRestart

### DIFF
--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -45,6 +45,9 @@ type Plan struct {
 	OneTimeInstructions  []OneTimeInstruction    `json:"instructions,omitempty"`
 	Probes               map[string]prober.Probe `json:"probes,omitempty"`
 	PeriodicInstructions []PeriodicInstruction   `json:"periodicInstructions,omitempty"`
+	// ResetFailureCountOnStartup denotes whether the system-agent should reset the failure count
+	// and applied-checksum for plans that are force applied each time the system-agent starts.
+	ResetFailureCountOnStartup bool `json:"resetFailureCountOnStartup,omitempty"`
 }
 
 type CommonInstruction struct {

--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -215,6 +215,12 @@ func (w *watcher) start(ctx context.Context, strictVerify bool) {
 				logrus.Infof("Detected first start, force-applying one-time instruction set")
 				needsApplied = true
 				hasRunOnce = true
+				// Plans which have previously succeeded but need to be force applied
+				// should continue to respect the specified failure count.
+				if cp.Plan.ResetFailureCountOnStartup {
+					secret.Data[appliedChecksumKey] = []byte("")
+					secret.Data[failureCountKey] = []byte("0")
+				}
 			}
 
 			// Check to see if we've exceeded our failure count threshold


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/42458, RFC-13

This PR adds the `ResetFailureCountOnStartup` field to the `OneTimeInstruction` struct. If this field is set to true, during the [initial force application of the one-time instruction set ](https://github.com/rancher/system-agent/blob/7ad21ffbe9273d33d28fbf17249e949fdc6d8610/pkg/k8splan/watcher.go#L214-L218) the plans `failure-count` and `applied-checksum` fields will be reset. This ensures that the `max-failures` field is always respected, even if the plan had previously succeeded when executed by a prior instance of the system-agent. Due to the fact that the `failure-count` and `applied-checksum` fields are stored at the top level (and not as an attribute of the `plan` key) this will occur if any of the one time instructions set `ResetFailureCountOnStartup` to true. 