### PR TITLE
fix: add retry logic for one time instruction

### DIFF
--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -215,10 +215,10 @@ func (w *watcher) start(ctx context.Context, strictVerify bool) {
 				logrus.Infof("Detected first start, force-applying one-time instruction set")
 				needsApplied = true
 				hasRunOnce = true
+				secret.Data[appliedChecksumKey] = []byte("")
 				// Plans which have previously succeeded but need to be force applied
 				// should continue to respect the specified failure count.
 				if cp.Plan.ResetFailureCountOnStartup {
-					secret.Data[appliedChecksumKey] = []byte("")
 					secret.Data[failureCountKey] = []byte("0")
 				}
 			}


### PR DESCRIPTION
This PR addresses issue https://github.com/rancher/rancher/issues/48916 by implementing retry logic for one-time instructions.

## Changes

- Added retry logic using `retry.OnError` for one-time instruction execution

## Testing

Manually tested.
Logs: 
```
root@ip-x.x.x.x:/home/ubuntu# journalctl -fu rancher-system-agent.service
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Rancher System Agent version 15b7568 (15b7568) is starting"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Using directory /var/lib/rancher/agent/work for work"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Starting remote watch of plans"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Initial connection to Kubernetes cluster failed with error Get \"https://69c34c5e4eeb.ngrok.app/version\": tls: failed to verify certificate: x509: certificate signed by unknown authority, removing CA data and trying again"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Starting /v1, Kind=Secret controller"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Detected first start, force-applying one-time instruction set"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="[Applyinator] Applying one-time instructions for plan with checksum 0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="[Applyinator] Extracting image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1 to directory /var/lib/rancher/agent/work/20250326-231340/0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749_0"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Using private registry config file at /etc/rancher/agent/registries.yaml"
rancher-system-agent[82604]: time="2025-03-26T23:13:40Z" level=info msg="Pulling image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
rancher-system-agent[82604]: time="2025-03-26T23:14:41Z" level=warning msg="Failed to get image from endpoint: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout"
rancher-system-agent[82604]: time="2025-03-26T23:14:41Z" level=error msg="error while staging: all endpoints failed: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout: failed to get image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"

rancher-system-agent[82604]: time="2025-03-26T23:14:41Z" level=error msg="[Applyinator] Execution failed: all endpoints failed: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout: failed to get image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
rancher-system-agent[82604]: time="2025-03-26T23:14:41Z" level=info msg="[Applyinator] (attempt #1) Applying one-time instructions for plan with checksum 0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749"
rancher-system-agent[82604]: time="2025-03-26T23:14:41Z" level=info msg="[Applyinator] (attempt #1) Retrying instruction 0 for plan 0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749"
rancher-system-agent[82604]: time="2025-03-26T23:14:44Z" level=info msg="[Applyinator] Extracting image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1 to directory /var/lib/rancher/agent/work/20250326-231340/0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749_0"
rancher-system-agent[82604]: time="2025-03-26T23:14:44Z" level=info msg="Using private registry config file at /etc/rancher/agent/registries.yaml"
rancher-system-agent[82604]: time="2025-03-26T23:14:44Z" level=info msg="Pulling image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
rancher-system-agent[82604]: time="2025-03-26T23:15:14Z" level=warning msg="Failed to get image from endpoint: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout"
rancher-system-agent[82604]: time="2025-03-26T23:15:14Z" level=error msg="error while staging: all endpoints failed: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout: failed to get image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"

rancher-system-agent[82604]: time="2025-03-26T23:15:14Z" level=error msg="[Applyinator] Execution failed: all endpoints failed: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout: failed to get image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
rancher-system-agent[82604]: time="2025-03-26T23:15:14Z" level=info msg="[Applyinator] (attempt #2) Applying one-time instructions for plan with checksum 0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749"
rancher-system-agent[82604]: time="2025-03-26T23:15:14Z" level=info msg="[Applyinator] (attempt #2) Retrying instruction 0 for plan 0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749"
rancher-system-agent[82604]: time="2025-03-26T23:15:20Z" level=info msg="[Applyinator] Extracting image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1 to directory /var/lib/rancher/agent/work/20250326-231340/0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749_0"
rancher-system-agent[82604]: time="2025-03-26T23:15:20Z" level=info msg="Using private registry config file at /etc/rancher/agent/registries.yaml"
rancher-system-agent[82604]: time="2025-03-26T23:15:20Z" level=info msg="Pulling image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
rancher-system-agent[82604]: time="2025-03-26T23:15:50Z" level=warning msg="Failed to get image from endpoint: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout"
rancher-system-agent[82604]: time="2025-03-26T23:15:50Z" level=error msg="error while staging: all endpoints failed: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout: failed to get image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"

rancher-system-agent[82604]: time="2025-03-26T23:15:50Z" level=error msg="[Applyinator] Execution failed: all endpoints failed: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout: failed to get image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
rancher-system-agent[82604]: time="2025-03-26T23:15:50Z" level=info msg="[Applyinator] (attempt #3) Applying one-time instructions for plan with checksum 0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749"
rancher-system-agent[82604]: time="2025-03-26T23:15:50Z" level=info msg="[Applyinator] (attempt #3) Retrying instruction 0 for plan 0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749"
rancher-system-agent[82604]: time="2025-03-26T23:16:03Z" level=info msg="[Applyinator] Extracting image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1 to directory /var/lib/rancher/agent/work/20250326-231340/0395dd07720d0f5717be20792c5b0aa2b5d09ca0d60592eb90b432a26f534749_0"
rancher-system-agent[82604]: time="2025-03-26T23:16:03Z" level=info msg="Using private registry config file at /etc/rancher/agent/registries.yaml"
rancher-system-agent[82604]: time="2025-03-26T23:16:03Z" level=info msg="Pulling image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
rancher-system-agent[82604]: time="2025-03-26T23:17:33Z" level=warning msg="Failed to get image from endpoint: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout"
rancher-system-agent[82604]: time="2025-03-26T23:17:33Z" level=error msg="error while staging: all endpoints failed: Get \"https://privateRegistry.com:5000/v2/\": dial tcp y.y.y.y:5000: i/o timeout: failed to get image privateRegistry.com:5000/rancher/system-agent-installer-rke2:v1.31.6-rke2r1"
```