### PR TITLE
Get UID/GID for current user in write file_test.go

### DIFF
--- a/pkg/applyinator/file_test.go
+++ b/pkg/applyinator/file_test.go
@@ -21,9 +21,11 @@ func TestWriteContentToFile(t *testing.T) {
 
 	getFile := func(path string, permissions string, content string) File {
 		return File{
-			Permissions: permissions,
-			Path:        filepath.Join(tempDir, path),
 			Content:     content,
+			UID:         -1,
+			GID:         -1,
+			Path:        filepath.Join(tempDir, path),
+			Permissions: permissions,
 		}
 	}
 
@@ -157,8 +159,10 @@ func TestCreateDirectory(t *testing.T) {
 	getFile := func(path string, permissions string) File {
 		return File{
 			Directory:   true,
-			Permissions: permissions,
+			UID:         -1,
+			GID:         -1,
 			Path:        filepath.Join(tempDir, path),
+			Permissions: permissions,
 		}
 	}
 


### PR DESCRIPTION
This can just get merged whenever, it's just to enable these tests to run locally. I've confirmed they work both with `go test ./...` and `make test`.