### PR TITLE
Drop windows 2019 when running PR CI

### DIFF
--- a/.github/workflows/ci-on-pull-request.yaml
+++ b/.github/workflows/ci-on-pull-request.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows ]
-        platform: [ windows-2019, windows-latest ]
+        platform: [ windows-2022 ]
         arch: [ amd64 ]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
### Issue: https://github.com/rancher/rancher/issues/50500

GHA is dropping Windows 2019 support on June 30th, so we can't continue using it in our PR CI. I kept the 2022 step, so we aren't really losing much test coverage anyway. 