### PR TITLE
Best Effort Handling of NO_PROXY

### DIFF
--- a/package/suc/run.sh
+++ b/package/suc/run.sh
@@ -13,6 +13,11 @@ cleanup() {
     rm -rf "/host${TMPDIR}"
 }
 
+no_proxy_usage() {
+    echo "WARNING: Malformed NO_PROXY environment variable value format, detected whitespace in value. Value must be a comma-delimited string with no spaces containing one or more IP address prefixes (1.2.3.4, 1.2.3.4:80), IP address prefixes in CIDR notation (1.2.3.4/8), domain names, or special DNS labels (*)"
+    echo "WARNING: Will automatically remove detected whitespace. This may lead to unexpected behavior."
+}
+
 trap cleanup EXIT
 trap exit INT HUP TERM
 
@@ -43,14 +48,37 @@ export CATTLE_AGENT_BINARY_LOCAL=true
 export CATTLE_AGENT_UNINSTALL_LOCAL=true
 export CATTLE_AGENT_BINARY_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent
 export CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent-uninstall.sh
+
 if [ -s /host/etc/systemd/system/rancher-system-agent.env ]; then
-  for line in $(grep -v '^#' /host/etc/systemd/system/rancher-system-agent.env); do
+    # Read line by line, skipping any variables that are commented out (#)
+    grep -v '^#' /host/etc/systemd/system/rancher-system-agent.env | while IFS= read -r line; do
+
+    # Determine the name and previously set
+    # value of the environment variable
     var=${line%%=*}
     val=${line##*=}
+
+    # Check if the variable is already exported.
     eval v=\"\$$var\"
+    # If a previously seen environment variable isn't currently exported,
+    # reuse the last known value stored in the environment variables file
     if [ -z "$v" ]; then
       export "$var=$val"
+      v="$val"
     fi
+
+    # If NO_PROXY is set, ensure it meets the minimum format requirements (no spaces).
+    if [ "$var" = "NO_PROXY" ] || [ "$var" = "no_proxy" ]; then
+        if [ -n "$v" ]; then
+            if echo "$v" | grep -q " "; then
+                no_proxy_usage
+                v="$(echo "$v" | tr -d '[:space:]')"
+                export "$var=$v"
+            fi
+        fi
+    fi
+
   done
 fi
+
 chroot /host ${TMPDIR}/install.sh "$@"


### PR DESCRIPTION
### Issue: https://github.com/rancher/rancher/issues/50041

Passing a `NO_PROXY` value which includes spaces has the potential to break the upgrade script. This is due to `run.sh` iterating across previously set environment variables using white space as a delimiter, instead of new lines, and due to how `install.sh` parses the set `NO_PROXY` environment variable when crafting curl requests.

From what I can determine, including whitespace in `NO_PROXY` is a misconfiguration of the variable. Unfortunately, documentation doesn't explicitly state the expected format of `NO_PROXY`. However, all examples of `NO_PROXY` in Rancher strictly follow the expected Go format (comma-delimited entries). I have an associated docs PR up to clarify the expected value.

At the moment, In the event that `NO_PROXY` is not already exported, and needs to be reapplied using the value in `rancher-system-agent.env`, only the contents before the first whitespace character will be properly set to `NO_PROXY`. The remainder of the values will be exported individually, with no effect, polluting the SUC job logs.

This change updates `run.sh` to add best effort handling of this case, and to print a useful warning message when a malformed value is provided. It also updates the loop to break on newlines, and not whitespace.

### Testing

After making these changes I built a new system-agent SUC image and tested it against a local custom cluster. I was able to confirm that no change in behavior occurs when properly setting `NO_PROXY`, and that an upgrade to a system-agent with this change does not result in a restart of rke2. 

When `NO_PROXY` included one or more spaces, I confirmed that the expected warning message was printed to the job logs and that the errant spaces were removed before exporting `NO_PROXY` and invoking `install.sh`. 