### PR TITLE
Remove resetFailureCountOnStartup

### DIFF
--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -45,9 +45,6 @@ type Plan struct {
 	OneTimeInstructions  []OneTimeInstruction    `json:"instructions,omitempty"`
 	Probes               map[string]prober.Probe `json:"probes,omitempty"`
 	PeriodicInstructions []PeriodicInstruction   `json:"periodicInstructions,omitempty"`
-	// ResetFailureCountOnStartup denotes whether the system-agent should reset the failure count
-	// and applied-checksum for plans that are force applied each time the system-agent starts.
-	ResetFailureCountOnStartup bool `json:"resetFailureCountOnStartup,omitempty"`
 }
 
 type CommonInstruction struct {

--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -216,11 +216,7 @@ func (w *watcher) start(ctx context.Context, strictVerify bool) {
 				needsApplied = true
 				hasRunOnce = true
 				secret.Data[appliedChecksumKey] = []byte("")
-				// Plans which have previously succeeded but need to be force applied
-				// should continue to respect the specified failure count.
-				if cp.Plan.ResetFailureCountOnStartup {
-					secret.Data[failureCountKey] = []byte("0")
-				}
+				secret.Data[failureCountKey] = []byte("0")
 			}
 
 			// Check to see if we've exceeded our failure count threshold


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50077

+ Remove the `ResetFailureCountOnStartup` field from the plan struct, as it's no longer useful 
   + `ResetFailureCountOnStartup` was only ever being used by Windows plans, which no longer need to use it. 
+ Always reset the failure count when executing plans after a reboot of the system-agent 
   + I scoped this to just Windows nodes during the initial implementation to avoid any potential regressions, but thinking about it more it should have been done this way from the get-go 
