### PR TITLE
Ensure `run.sh` triggers the cleanup trap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ fi
 #   - CATTLE_AGENT_STRICT_VERIFY | STRICT_VERIFY (default: false)
 #   - CATTLE_AGENT_FALLBACK_PATH (default: )
 
-FALLBACK=v0.2.9
+FALLBACK=v0.3.13
 CACERTS_PATH=cacerts
 RETRYCOUNT=4500
 APPLYINATOR_ACTIVE_WAIT_COUNT=60 # If the system-agent is unhealthy but had created an interlock file to indicate it was actively applying a plan, after 5 minutes, ignore the interlock.

--- a/package/suc/run.sh
+++ b/package/suc/run.sh
@@ -10,6 +10,9 @@ mkdir -p "/host${TMPDIRBASE}"
 TMPDIR=$(chroot /host /bin/sh -c "mktemp -d -p ${TMPDIRBASE}")
 
 cleanup() {
+    if [ -n $INSTALL_PID ] && kill -0 "${INSTALL_PID}" >/dev/null 2>&1; then
+        kill -TERM "${INSTALL_PID}" >/dev/null 2>&1
+    fi
     rm -rf "/host${TMPDIR}"
 }
 
@@ -53,4 +56,9 @@ if [ -s /host/etc/systemd/system/rancher-system-agent.env ]; then
     fi
   done
 fi
-chroot /host ${TMPDIR}/install.sh "$@"
+
+chroot /host ${TMPDIR}/install.sh "$@" &
+INSTALL_PID=$!
+# wait on the install script to free up trap handling
+# ref: https://www.gnu.org/software/bash/manual/html_node/Signals.html#Signals-1
+wait $INSTALL_PID


### PR DESCRIPTION
### Issue
https://github.com/rancher/rancher/issues/49260

### Problem

In some environments `run.sh` can leave behind temporary directories, which can eventually lead to disk pressure. 

In the event that the SUC upgrade job is kicked off in a downstream cluster at a time when Rancher is unavailable, the install script will reattempt the connection until the job times out and is killed by k8s. This can happen due to an incorrect proxy configuration, or if the Rancher server is unresponsive but the proxy still works. While there is a trap responsible for cleaning up the temporary directory, it will not fire in this scenario.

My understanding is that this is due to the following quirk of traps,
```
If Bash is waiting for a command to complete and receives a signal for which a trap has been set, 
it will not execute the trap until the command completes. 
```

https://www.gnu.org/software/bash/manual/html_node/Signals.html#Signals-1

In this case, the script is waiting on the `chroot /host ${TMPDIR}/install.sh "$@"` command to return, which is endlessly reattempting a connection to the Rancher server and will not return.

Also, the fallback version is really out of date

### Solution
Run `install.sh` using `&` and use `wait` to explicitly wait on the process when handling a signals via the existing trap. This allows the script to delete the temporary directory and exit before k8s sends a SIGKILL (which cannot be trapped).

This solution follows the guidance given in the above link
```
If Bash is waiting for an asynchronous command via the wait builtin, and it receives a signal 
for which a trap has been set, the wait builtin will return immediately with an exit status 
greater than 128, immediately after which the shell executes the trap.
```

I'm pretty sure this is portable, my understanding is that `wait` is a bash command and not tied to a specific binary included in distros. Please lmk if I'm mistaken about this though. 

### Additional details

The root issue can be easily reproduced by standing up Rancher behind ngrok, provisioning a cluster, stopping the ngrok session, and modifying the system-upgrade-controller plan via `kubectl`. 
