### PR TITLE
fix: Do not unconditionally reset failure-counts

### DIFF
--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -216,7 +216,6 @@ func (w *watcher) start(ctx context.Context, strictVerify bool) {
 				needsApplied = true
 				hasRunOnce = true
 				secret.Data[appliedChecksumKey] = []byte("")
-				secret.Data[failureCountKey] = []byte("0")
 			}
 
 			// Check to see if we've exceeded our failure count threshold


### PR DESCRIPTION
### Issue: https://github.com/rancher/rancher/issues/50077

### Problem
The prior PR for this issue updated the system-agent to always reset the `failure-count` property on the plan being executed if it was being run after a restart. While at a glance this seems reasonable, it actually introduces edge cases around etcd snapshot creation/restore operations that could result in unexpected creation of snapshots. In general, unconditionally resetting `failure-count` also has the potential to break other commands wrapped in the `idempotentcy` [script maintained within rancher/rancher](https://github.com/rancher/rancher/blob/main/pkg/capr/planner/idempotent.go).

### Solution
Don't reset the failure count after a restart of the system-agent. The primary draw back of this change is that operations which have been attempted up to their max-failure count will not be reattempted after a restart. 

I feel that this is acceptable because, afaik, Rancher only sets the `max-failure` count to a non-negative number when performing sensitive operations, such as etcd operations or encryption key rotation, and not when generally reconciling nodes. 

In these cases, a true failure to apply the plan really _should_ be investigated and either
1. reattempted as a whole, via the UI or API
2. manually resolved after considering any implications that changing the `failure-count` on a per-plan level may have on the cluster stability / etcd snapshot creation. 

Note that this is just maintaining the current the behavior of released versions of the system-agent. The only case where `failure-count` was being reset was when processing Windows nodes, which do not perform any actions in the etcd snapshot/restore or encryption key rotation processes. 