### PR TITLE
install.sh: enforce 0644 on rancher-system-agent.service regardless of umask

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -577,6 +577,8 @@ Environment=CATTLE_AGENT_CONFIG=${CATTLE_AGENT_CONFIG_DIR}/config.yaml
 Environment=CATTLE_AGENT_STRICT_VERIFY=${CATTLE_AGENT_STRICT_VERIFY}
 ExecStart=${CATTLE_AGENT_BIN_PREFIX}/bin/rancher-system-agent sentinel
 EOF
+# Ensure predictable, world-readable unit perms even under hardened umask (e.g., 027)
+chmod 0644 /etc/systemd/system/rancher-system-agent.service || true
 }
 
 download_rancher_files() {


### PR DESCRIPTION
### Problem
On hosts with a hardened umask (e.g., 027), `/etc/systemd/system/rancher-system-agent.service`
is created as 0640, triggering systemd’s “world-inaccessible” warning.

### Fix
Right after writing the unit file in `create_systemd_service_file()`,
explicitly `chmod 0644 /etc/systemd/system/rancher-system-agent.service`.


### Repro
1) `umask 027`
2) Run installer → unit was 0640 and warning appears.
3) With this patch → unit is 0644 and warning is gone.

