### PR TITLE
align system-agent image publishing for signed releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   # Build Docker images using multi-stage Dockerfile
   release:
-    name: Build and push images
+    name: Build and push arch-specific images
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,45 +36,95 @@ jobs:
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials registry | PRIME_STG_REGISTRY ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | PRIME_STG_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | PRIME_STG_REGISTRY_PASSWORD
 
-      - name: Publish Image
-        uses: rancher/ecm-distro-tools/actions/publish-image@master
+      - name: Publish main image to DockerHub and Prime Staging
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
         env:
-          TAG: ${{ github.ref_name }}
-          ARCH: ${{ matrix.arch }}
-          GOOS: linux
-          TAG_SUFFIX: ${{ matrix.tag-suffix }}
           COMMIT: ${{ github.sha }}
         with:
           image: "system-agent"
-          tag: ${{ github.ref_name }}
-          make-target: docker-buildx-push
+          tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}
+          platforms: linux/${{ matrix.arch }}
+          make-target: push-image
+          prime-make-target: push-prime-image
 
+          public-registry: docker.io
           public-repo: rancher
           public-username: ${{ env.DOCKER_USERNAME }}
           public-password: ${{ env.DOCKER_PASSWORD }}
 
-          push-to-prime: false
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_STG_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_STG_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
 
-      - name: Publish Image
-        uses: rancher/ecm-distro-tools/actions/publish-image@master
+      - name: Publish main image to Prime Prod
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
         env:
-          TAG: ${{ github.ref_name }}
-          ARCH: ${{ matrix.arch }}
-          GOOS: linux
-          TAG_SUFFIX: ${{ matrix.tag-suffix }}
           COMMIT: ${{ github.sha }}
         with:
           image: "system-agent"
-          tag: ${{ github.ref_name }}
-          make-target: docker-buildx-push-suc
+          tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}
+          platforms: linux/${{ matrix.arch }}
+          make-target: push-image
+          prime-make-target: push-prime-image
 
+          push-to-public: false
+
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+
+      - name: Publish SUC image to DockerHub and Prime Staging
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
+        env:
+          COMMIT: ${{ github.sha }}
+        with:
+          image: "system-agent"
+          tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}-suc
+          platforms: linux/${{ matrix.arch }}
+          make-target: push-image-suc
+          prime-make-target: push-prime-image-suc
+
+          public-registry: docker.io
           public-repo: rancher
           public-username: ${{ env.DOCKER_USERNAME }}
           public-password: ${{ env.DOCKER_PASSWORD }}
 
-          push-to-prime: false
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_STG_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_STG_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
+
+      - name: Publish SUC image to Prime Prod
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
+        env:
+          COMMIT: ${{ github.sha }}
+        with:
+          image: "system-agent"
+          tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}-suc
+          platforms: linux/${{ matrix.arch }}
+          make-target: push-image-suc
+          prime-make-target: push-prime-image-suc
+
+          push-to-public: false
+
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
 
   merge:
     runs-on: ubuntu-latest
@@ -89,22 +139,83 @@ jobs:
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials registry | PRIME_STG_REGISTRY ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | PRIME_STG_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | PRIME_STG_REGISTRY_PASSWORD
 
-      - name: Create and push multi-platform manifests
-        uses: rancher/ecm-distro-tools/actions/publish-image@master
-        env:
-          TAG: ${{ github.ref_name }}
+      - name: Publish main manifest to DockerHub and Prime Staging
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
         with:
           image: "system-agent"
           tag: ${{ github.ref_name }}
-          make-target: docker-manifest
+          make-target: push-manifest
+          prime-make-target: push-prime-manifest
 
+          public-registry: docker.io
           public-repo: rancher
           public-username: ${{ env.DOCKER_USERNAME }}
           public-password: ${{ env.DOCKER_PASSWORD }}
 
-          push-to-prime: false
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_STG_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_STG_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
+
+      - name: Publish main manifest to Prime Prod
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
+        with:
+          image: "system-agent"
+          tag: ${{ github.ref_name }}
+          make-target: push-manifest
+          prime-make-target: push-prime-manifest
+
+          push-to-public: false
+
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+
+      - name: Publish SUC manifest to DockerHub and Prime Staging
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
+        with:
+          image: "system-agent"
+          tag: ${{ github.ref_name }}-suc
+          make-target: push-manifest-suc
+          prime-make-target: push-prime-manifest-suc
+
+          public-registry: docker.io
+          public-repo: rancher
+          public-username: ${{ env.DOCKER_USERNAME }}
+          public-password: ${{ env.DOCKER_PASSWORD }}
+
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_STG_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_STG_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
+
+      - name: Publish SUC manifest to Prime Prod
+        uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
+        with:
+          image: "system-agent"
+          tag: ${{ github.ref_name }}-suc
+          make-target: push-manifest-suc
+          prime-make-target: push-prime-manifest-suc
+
+          push-to-public: false
+
+          push-to-prime: true
+          prime-registry: ${{ env.PRIME_REGISTRY }}
+          prime-repo: rancher
+          prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
+          prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
 
   github_release:
     name: Create GitHub release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,12 +31,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
       - name: Read Vault secrets
         uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # main
         with:
@@ -44,29 +38,43 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
 
-      - name: Log into Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - name: Publish Image
+        uses: rancher/ecm-distro-tools/actions/publish-image@master
+        env:
+          TAG: ${{ github.ref_name }}
+          ARCH: ${{ matrix.arch }}
+          GOOS: linux
+          TAG_SUFFIX: ${{ matrix.tag-suffix }}
+          COMMIT: ${{ github.sha }}
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+          image: "system-agent"
+          tag: ${{ github.ref_name }}
+          make-target: docker-buildx-push
 
-      - name: Build and push system-agent image
-        run: make docker-buildx-push
+          public-repo: rancher
+          public-username: ${{ env.DOCKER_USERNAME }}
+          public-password: ${{ env.DOCKER_PASSWORD }}
+
+          push-to-prime: false
+
+      - name: Publish Image
+        uses: rancher/ecm-distro-tools/actions/publish-image@master
         env:
           TAG: ${{ github.ref_name }}
           ARCH: ${{ matrix.arch }}
           GOOS: linux
           TAG_SUFFIX: ${{ matrix.tag-suffix }}
           COMMIT: ${{ github.sha }}
+        with:
+          image: "system-agent"
+          tag: ${{ github.ref_name }}
+          make-target: docker-buildx-push-suc
 
-      - name: Build and push system-agent-suc image
-        run: make docker-buildx-push-suc
-        env:
-          TAG: ${{ github.ref_name }}
-          ARCH: ${{ matrix.arch }}
-          GOOS: linux
-          TAG_SUFFIX: ${{ matrix.tag-suffix }}
-          COMMIT: ${{ github.sha }}
+          public-repo: rancher
+          public-username: ${{ env.DOCKER_USERNAME }}
+          public-password: ${{ env.DOCKER_PASSWORD }}
+
+          push-to-prime: false
 
   merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Publish main image to DockerHub and Prime Staging
         uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
-        env:
-          COMMIT: ${{ github.sha }}
         with:
           image: "system-agent"
           tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}
@@ -67,9 +65,8 @@ jobs:
           prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
 
       - name: Publish main image to Prime Prod
+        if: ${{ !contains(github.ref_name, '-rc') }}
         uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
-        env:
-          COMMIT: ${{ github.sha }}
         with:
           image: "system-agent"
           tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}
@@ -87,8 +84,6 @@ jobs:
 
       - name: Publish SUC image to DockerHub and Prime Staging
         uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
-        env:
-          COMMIT: ${{ github.sha }}
         with:
           image: "system-agent"
           tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}-suc
@@ -108,9 +103,8 @@ jobs:
           prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
 
       - name: Publish SUC image to Prime Prod
+        if: ${{ !contains(github.ref_name, '-rc') }}
         uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
-        env:
-          COMMIT: ${{ github.sha }}
         with:
           image: "system-agent"
           tag: ${{ github.ref_name }}-${{ matrix.tag-suffix }}-suc
@@ -167,6 +161,7 @@ jobs:
           prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
 
       - name: Publish main manifest to Prime Prod
+        if: ${{ !contains(github.ref_name, '-rc') }}
         uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
         with:
           image: "system-agent"
@@ -202,6 +197,7 @@ jobs:
           prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
 
       - name: Publish SUC manifest to Prime Prod
+        if: ${{ !contains(github.ref_name, '-rc') }}
         uses: rancher/ecm-distro-tools/actions/publish-image@10ab39987d39be83da6a252c1c3b540e496e0287 # master
         with:
           image: "system-agent"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,16 +91,20 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
 
-      - name: Log into Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-
       - name: Create and push multi-platform manifests
-        run: make docker-manifest
+        uses: rancher/ecm-distro-tools/actions/publish-image@master
         env:
           TAG: ${{ github.ref_name }}
+        with:
+          image: "system-agent"
+          tag: ${{ github.ref_name }}
+          make-target: docker-manifest
+
+          public-repo: rancher
+          public-username: ${{ env.DOCKER_USERNAME }}
+          public-password: ${{ env.DOCKER_PASSWORD }}
+
+          push-to-prime: false
 
   github_release:
     name: Create GitHub release

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,14 @@ ARCH ?= $(shell go env GOARCH)
 TARGET_OS ?= $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 REGISTRY ?= docker.io
 ORG ?= rancher
+REPO ?= $(REGISTRY)/$(ORG)
 IMAGE_NAME ?= system-agent
 IMAGE ?= $(REGISTRY)/$(ORG)/$(IMAGE_NAME)
 TAG_SUFFIX ?= $(TARGET_OS)-$(ARCH)
+BUILDX_BUILDER ?= system-agent
+IMAGE_BUILDER ?= docker buildx
+DEFAULT_PLATFORMS := linux/amd64,linux/arm64
+BUILDX_ARGS ?= --provenance=false --sbom=false
 
 # Build flags
 LDFLAGS := -X github.com/rancher/system-agent/pkg/version.Version=$(VERSION)
@@ -266,37 +271,130 @@ docker-build-suc: ## Build SUC Docker image locally (no push)
 
 ##@ Docker (Release - used by CI/CD workflows)
 
+.PHONY: buildx-builder
+buildx-builder:
+	@docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1 || docker buildx create --name=$(BUILDX_BUILDER) --platform=$(DEFAULT_PLATFORMS)
+
+.PHONY: buildx-release
+buildx-release: buildx-builder
+	@bash -c 'set -euo pipefail; \
+		BUILDX_PLATFORM="$${BUILDX_PLATFORM:-$${TARGET_PLATFORMS:-linux/$(ARCH)}}"; \
+		$(IMAGE_BUILDER) build \
+			$${IID_FILE_FLAG:-} \
+			$${BUILDX_BUILDER_FLAG:+--builder $${BUILDX_BUILDER_FLAG}} \
+			--build-arg VERSION="$(VERSION)" \
+			--build-arg COMMIT="$(COMMIT)" \
+			$${BUILDX_TARGET:+--target $${BUILDX_TARGET}} \
+			$${BUILDX_PLATFORM:+--platform $${BUILDX_PLATFORM}} \
+			$${BUILDX_TAG_ARGS:-} \
+			$${BUILDX_EXTRA_ARGS:-} \
+			$${BUILDX_PUSH:+--push} \
+			.'
+
+.PHONY: push-image
+push-image: ## Build and push a tagged system-agent image
+	@echo "--- Building and Pushing Image ---"
+	@bash -c 'set -euo pipefail; \
+		IMAGE="$${REPO}/$(IMAGE_NAME):$${TAG}"; \
+		$(MAKE) --no-print-directory buildx-release \
+			BUILDX_BUILDER_FLAG="$(BUILDX_BUILDER)" \
+			BUILDX_TARGET=system-agent \
+			BUILDX_TAG_ARGS="--tag $${IMAGE}" \
+			BUILDX_EXTRA_ARGS="$(BUILDX_ARGS)" \
+			BUILDX_PUSH=1 \
+			IID_FILE_FLAG="$${IID_FILE_FLAG:-}"; \
+		echo "Pushed $${IMAGE}"'
+
+.PHONY: push-prime-image
+push-prime-image: ## Build and push a tagged system-agent image with prime attestations
+	@$(MAKE) --no-print-directory push-image \
+		BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max"
+
+.PHONY: push-image-suc
+push-image-suc: ## Build and push a tagged system-agent SUC image
+	@echo "--- Building and Pushing SUC Image ---"
+	@bash -c 'set -euo pipefail; \
+		IMAGE="$${REPO}/$(IMAGE_NAME):$${TAG}"; \
+		$(MAKE) --no-print-directory buildx-release \
+			BUILDX_BUILDER_FLAG="$(BUILDX_BUILDER)" \
+			BUILDX_TARGET=system-agent-suc \
+			BUILDX_TAG_ARGS="--tag $${IMAGE}" \
+			BUILDX_EXTRA_ARGS="$(BUILDX_ARGS)" \
+			BUILDX_PUSH=1 \
+			IID_FILE_FLAG="$${IID_FILE_FLAG:-}"; \
+		echo "Pushed $${IMAGE}"'
+
+.PHONY: push-prime-image-suc
+push-prime-image-suc: ## Build and push a tagged system-agent SUC image with prime attestations
+	@$(MAKE) --no-print-directory push-image-suc \
+		BUILDX_ARGS="--sbom=true --attest type=provenance,mode=max"
+
+.PHONY: push-manifest
+push-manifest: ## Create and push a multi-platform system-agent manifest
+	@echo "--- Creating and Pushing Manifest ---"
+	@bash -c 'set -euo pipefail; \
+		IMAGE="$${REPO}/$(IMAGE_NAME):$${TAG}"; \
+		docker buildx imagetools create -t "$${IMAGE}" \
+			"$${REPO}/$(IMAGE_NAME):$${TAG}-linux-amd64" \
+			"$${REPO}/$(IMAGE_NAME):$${TAG}-linux-arm64"; \
+		if [ -n "$${IID_FILE:-}" ]; then \
+			digest=$$(docker buildx imagetools inspect "$${IMAGE}" | sed -n "s/^Digest:[[:space:]]*//p" | head -n 1); \
+			printf "%s\n" "$${digest}" > "$${IID_FILE}"; \
+		fi; \
+		echo "Pushed $${IMAGE}"'
+
+.PHONY: push-prime-manifest
+push-prime-manifest: ## Create and push a multi-platform system-agent manifest for prime signing
+	@$(MAKE) --no-print-directory push-manifest
+
+.PHONY: push-manifest-suc
+push-manifest-suc: ## Create and push a multi-platform system-agent SUC manifest
+	@echo "--- Creating and Pushing SUC Manifest ---"
+	@bash -c 'set -euo pipefail; \
+		BASE_TAG="$${TAG%-suc}"; \
+		if [ "$${BASE_TAG}" = "$${TAG}" ]; then \
+			echo "TAG must end with -suc"; \
+			exit 1; \
+		fi; \
+		IMAGE="$${REPO}/$(IMAGE_NAME):$${TAG}"; \
+		docker buildx imagetools create -t "$${IMAGE}" \
+			"$${REPO}/$(IMAGE_NAME):$${BASE_TAG}-linux-amd64-suc" \
+			"$${REPO}/$(IMAGE_NAME):$${BASE_TAG}-linux-arm64-suc"; \
+		if [ -n "$${IID_FILE:-}" ]; then \
+			digest=$$(docker buildx imagetools inspect "$${IMAGE}" | sed -n "s/^Digest:[[:space:]]*//p" | head -n 1); \
+			printf "%s\n" "$${digest}" > "$${IID_FILE}"; \
+		fi; \
+		echo "Pushed $${IMAGE}"'
+
+.PHONY: push-prime-manifest-suc
+push-prime-manifest-suc: ## Create and push a multi-platform system-agent SUC manifest for prime signing
+	@$(MAKE) --no-print-directory push-manifest-suc
+
 .PHONY: docker-buildx-push
-docker-buildx-push: ## Build and push Docker image with buildx (used by release workflow)
-	docker buildx build --platform=linux/$(ARCH) \
-		--build-arg VERSION=$(VERSION) \
-		--build-arg COMMIT=$(COMMIT) \
-		--target system-agent \
-		-t $(IMAGE):$(TAG)-$(TAG_SUFFIX) \
-		--push .
-	@echo "Built and pushed $(IMAGE):$(TAG)-$(TAG_SUFFIX)"
+docker-buildx-push: ## Build and push Docker image with buildx (legacy release target)
+	@$(MAKE) --no-print-directory push-image TAG="$(TAG)-$(TAG_SUFFIX)"
+
+.PHONY: docker-buildx-push-prime
+docker-buildx-push-prime: ## Build and push Docker image with buildx for prime signing
+	@$(MAKE) --no-print-directory push-prime-image TAG="$(TAG)-$(TAG_SUFFIX)"
 
 .PHONY: docker-buildx-push-suc
-docker-buildx-push-suc: ## Build and push SUC Docker image with buildx (used by release workflow)
-	docker buildx build --platform=linux/$(ARCH) \
-		--build-arg VERSION=$(VERSION) \
-		--build-arg COMMIT=$(COMMIT) \
-		--target system-agent-suc \
-		-t $(IMAGE):$(TAG)-$(TAG_SUFFIX)-suc \
-		--push .
-	@echo "Built and pushed $(IMAGE):$(TAG)-$(TAG_SUFFIX)-suc"
+docker-buildx-push-suc: ## Build and push SUC Docker image with buildx (legacy release target)
+	@$(MAKE) --no-print-directory push-image-suc TAG="$(TAG)-$(TAG_SUFFIX)-suc"
+
+.PHONY: docker-buildx-push-suc-prime
+docker-buildx-push-suc-prime: ## Build and push SUC Docker image with buildx for prime signing
+	@$(MAKE) --no-print-directory push-prime-image-suc TAG="$(TAG)-$(TAG_SUFFIX)-suc"
 
 .PHONY: docker-manifest
-docker-manifest: ## Create and push multi-platform manifests (used by release workflow)
-	@echo "Creating multi-platform manifest for $(IMAGE):$(TAG)"
-	docker buildx imagetools create -t "$(IMAGE):$(TAG)" \
-		"$(IMAGE):$(TAG)-linux-amd64" \
-		"$(IMAGE):$(TAG)-linux-arm64"
-	@echo "Creating multi-platform manifest for $(IMAGE):$(TAG)-suc"
-	docker buildx imagetools create -t "$(IMAGE):$(TAG)-suc" \
-		"$(IMAGE):$(TAG)-linux-amd64-suc" \
-		"$(IMAGE):$(TAG)-linux-arm64-suc"
-	@echo "Multi-platform manifests pushed successfully"
+docker-manifest: ## Create and push multi-platform manifests (legacy release target)
+	@$(MAKE) --no-print-directory push-manifest
+	@$(MAKE) --no-print-directory push-manifest-suc TAG="$(TAG)-suc"
+
+.PHONY: docker-manifest-prime
+docker-manifest-prime: ## Create and push multi-platform manifests for prime signing
+	@$(MAKE) --no-print-directory push-prime-manifest
+	@$(MAKE) --no-print-directory push-prime-manifest-suc TAG="$(TAG)-suc"
 
 ##@ CI / CD
 


### PR DESCRIPTION
  ## Problem

  The system-agent release flow was not aligned with the current signed image publishing pattern used in related repos. 

  ## Solution

  This change aligns system-agent image publishing with the current shared release pattern while preserving the existing image tags and manifest layout.

  The repo-owned Makefile targets were refactored so the main and SUC images each have distinct standard and signed-release publish paths. The release workflow was updated to use those paths for both the arch-specific tags and the merged multi-arch tags, without changing the image names or tag formats consumed downstream.

  ## Testing

  Validated the updated publishing flow locally against a throwaway registry to confirm:
  - existing arch-specific tags are preserved
  - merged tags are still created as multi-arch manifests
  - the signed-release path produces the expected attached metadata