### PR TITLE
Add integration test infrastructure and initial system-agent tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,86 @@
+name: Integration Tests
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+          cache: true
+      - name: Configure Docker for cgroupfs/insecure-registry
+        run: |
+          echo '{"exec-opts": ["native.cgroupdriver=cgroupfs"], "insecure-registries": ["172.17.0.2:5000"]}' | sudo tee /etc/docker/daemon.json
+          if [ -d /run/systemd/system ]; then
+            sudo systemctl restart docker
+          fi
+          sudo docker info
+          # Alias 172.17.0.2 onto docker0 so the registry-cache is reachable.
+          sudo ip addr add 172.17.0.2/32 dev docker0
+      - name: Set up k3s binaries and CNI plugins
+        env:
+          CATTLE_K3S_VERSION: v1.35.3-k3s1
+        run: |
+          container_id=$(sudo docker create rancher/k3s:${CATTLE_K3S_VERSION})
+          for bin in blkid bandwidth cni conntrack containerd containerd-shim-runc-v2 ethtool firewall ip ipset k3s losetup pigz runc; do
+            sudo docker cp "${container_id}:/bin/${bin}" /usr/bin/ || true
+          done
+          sudo docker cp "${container_id}:/bin/aux/xtables-legacy-multi" /usr/bin/ || true
+          sudo docker rm "${container_id}"
+          sudo ln -sf /usr/bin/cni /usr/bin/bridge
+          sudo ln -sf /usr/bin/cni /usr/bin/flannel
+          sudo ln -sf /usr/bin/cni /usr/bin/host-local
+          sudo ln -sf /usr/bin/cni /usr/bin/loopback
+          sudo ln -sf /usr/bin/cni /usr/bin/portmap
+          sudo ln -sf /usr/bin/k3s /usr/bin/crictl
+          sudo ln -sf /usr/bin/k3s /usr/bin/ctr
+          sudo ln -sf /usr/bin/k3s /usr/bin/k3s-agent
+          sudo ln -sf /usr/bin/k3s /usr/bin/k3s-etcd-snapshot
+          sudo ln -sf /usr/bin/k3s /usr/bin/k3s-server
+          sudo ln -sf /usr/bin/k3s /usr/bin/kubectl
+          sudo ln -sf /usr/bin/pigz /usr/bin/unpigz
+          sudo ln -sf /usr/bin/xtables-legacy-multi /usr/bin/iptables
+          sudo ln -sf /usr/bin/xtables-legacy-multi /usr/bin/iptables-save
+          sudo ln -sf /usr/bin/xtables-legacy-multi /usr/bin/iptables-restore
+          sudo ln -sf /usr/bin/xtables-legacy-multi /usr/bin/ip6tables
+          sudo ln -sf /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-save
+          sudo ln -sf /usr/bin/xtables-legacy-multi /usr/bin/ip6tables-restore
+      - name: Pre-pull container images
+        env:
+          CATTLE_AGENT_IMAGE: rancher/rancher-agent:v2.14-head
+          RANCHER_IMAGE: rancher/rancher:v2.14-head
+        run: |
+          sudo docker pull "$RANCHER_IMAGE" &
+          sudo docker pull "$CATTLE_AGENT_IMAGE" &
+          wait
+      - name: Run integration tests
+        run: sudo -E env PATH="$PATH" make integration-tests
+      - name: Collect run artifacts
+        if: always()
+        run: |
+          mkdir -p _artifacts
+          [ -f /tmp/rancher.log ] && cp /tmp/rancher.log _artifacts/rancher.log || true
+          [ -n "$RANCHER_DIR" ] && [ -f "$RANCHER_DIR/build/testdata/k3s.log" ] && cp "$RANCHER_DIR/build/testdata/k3s.log" _artifacts/k3s.log || true
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: integration-test-artifacts
+          path: _artifacts
+          if-no-files-found: ignore

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -77,6 +77,7 @@ jobs:
           mkdir -p _artifacts
           [ -f /tmp/rancher.log ] && cp /tmp/rancher.log _artifacts/rancher.log || true
           [ -n "$RANCHER_DIR" ] && [ -f "$RANCHER_DIR/build/testdata/k3s.log" ] && cp "$RANCHER_DIR/build/testdata/k3s.log" _artifacts/k3s.log || true
+          [ -d /tmp/system-agent-streams ] && cp -R /tmp/system-agent-streams _artifacts/system-agent-streams || true
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,10 @@ test-e2e: $(GINKGO_BIN) e2e-image ## Run e2e tests (builds image and creates Kin
 		--junit-report="junit.e2e_suite.xml" \
 		./e2e/suites/...
 
+.PHONY: integration-tests
+integration-tests: ## Run integration tests (Rancher + system-agent + CAPR provisioning).
+	./scripts/integration-tests
+
 ##@ Build
 
 .PHONY: build

--- a/scripts/fetch-provisioning-tests
+++ b/scripts/fetch-provisioning-tests
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ex
+cd $(dirname $0)/..
+
+TMP_DIR=$(TMPDIR=/var/tmp mktemp -d)
+pushd "$TMP_DIR"
+
+mkdir -p rancher
+
+GIT_URL=${GIT_URL:-https://github.com/rancher/rancher.git}
+GIT_BRANCH=${GIT_BRANCH:-release/v2.14}
+
+git clone --depth 1 -b $GIT_BRANCH $GIT_URL ./rancher
+
+export RANCHER_DIR=$TMP_DIR/rancher
+
+pushd ./rancher
+if [ -n "$RANCHER_COMMIT" ]; then
+    git fetch --depth 1 origin "$RANCHER_COMMIT"
+    git checkout "$RANCHER_COMMIT"
+fi
+mkdir -p "$RANCHER_DIR/bin"
+
+# Extract the rancher binary from the container image.
+RANCHER_IMAGE=${RANCHER_IMAGE:-rancher/rancher:v2.14-head}
+docker pull "$RANCHER_IMAGE"
+container_id=$(docker create "$RANCHER_IMAGE")
+docker cp "$container_id":/usr/bin/rancher "$RANCHER_DIR/bin/rancher"
+docker cp "$container_id":/usr/bin/k3s "$RANCHER_DIR/bin/k3s"
+docker cp "$container_id":/usr/bin/rancher-machine "$RANCHER_DIR/bin/rancher-machine"
+docker rm "$container_id"
+
+# Tag the image as rancher/rancher:dev so provisioning-tests skips building
+# Rancher from source (it checks for rancher/rancher:$TAG where TAG=dev).
+docker tag "$RANCHER_IMAGE" rancher/rancher:dev
+
+popd
+
+popd

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -x
+
+cd "$(dirname "$0")/.." || exit 1
+
+SYSTEM_AGENT_DIR="$(pwd)"
+
+if [ "$V2PROV_TEST_DIST" != "rke2" ] && [ "$V2PROV_TEST_DIST" != "k3s" ]; then
+    export V2PROV_TEST_DIST=rke2
+fi
+
+if [ -z "${V2PROV_TEST_RUN_REGEX}" ]; then
+    export V2PROV_TEST_RUN_REGEX="^Test_(Provisioning_MP|PreBootstrap|SystemAgent)_.*$"
+fi
+
+export DRONE_BUILD_NUMBER=${GITHUB_RUN_NUMBER}
+
+set -ex
+
+make build
+
+mkdir -p /usr/share/rancher/ui/assets
+cp "${SYSTEM_AGENT_DIR}/install.sh" /usr/share/rancher/ui/assets/system-agent-install.sh
+
+source ./scripts/fetch-provisioning-tests
+
+# Copy system-agent integration tests into rancher's v2prov test tree.
+if compgen -G "${SYSTEM_AGENT_DIR}/test/integration/*_test.go" > /dev/null 2>&1; then
+    mkdir -p "${RANCHER_DIR}/tests/v2prov/tests/systemagent"
+    cp "${SYSTEM_AGENT_DIR}/test/integration/"*_test.go "${RANCHER_DIR}/tests/v2prov/tests/systemagent/"
+    sed -i '1{/^\/\/go:build ignore$/d}' "${RANCHER_DIR}/tests/v2prov/tests/systemagent/"*_test.go
+fi
+
+cd "$RANCHER_DIR"
+
+sed -i -e '3,5d' ./scripts/provisioning-tests
+
+# Use local system-agent binary instead of downloading from release server.
+sed -i "s|curl -sLf .* -o /usr/share/rancher/ui/assets/rancher-system-agent-amd64$|cp ${SYSTEM_AGENT_DIR}/bin/rancher-system-agent /usr/share/rancher/ui/assets/rancher-system-agent-amd64|" ./scripts/provisioning-tests
+sed -i "s|curl -sLf .* -o /usr/share/rancher/ui/assets/rancher-system-agent-arm64$|cp ${SYSTEM_AGENT_DIR}/bin/rancher-system-agent /usr/share/rancher/ui/assets/rancher-system-agent-arm64|" ./scripts/provisioning-tests
+sed -i "s|curl -sLf .* -o /usr/share/rancher/ui/assets/system-agent-uninstall.sh$|cp ${SYSTEM_AGENT_DIR}/system-agent-uninstall.sh /usr/share/rancher/ui/assets/system-agent-uninstall.sh|" ./scripts/provisioning-tests
+
+# Increase timeouts for 2-core GHA runners.
+sed -i 's|--timeout 300 "curl -sf -o /dev/null http://localhost:8080/ping"|--timeout 1200 "curl -sf -o /dev/null http://localhost:8080/ping"|' ./scripts/provisioning-tests
+sed -i 's/--timeout 300 `# Time out after 300 seconds/--timeout 600 `# Time out after 600 seconds/g' ./scripts/provisioning-tests
+sed -i 's|docker push 172\.17\.0\.2:5000/\$CATTLE_AGENT_IMAGE|docker tag \$CATTLE_AGENT_IMAGE 172.17.0.2:5000/\$CATTLE_AGENT_IMAGE \&\& docker push 172.17.0.2:5000/\$CATTLE_AGENT_IMAGE|' ./scripts/provisioning-tests
+sed -i 's/--timeout 300 \\$/--timeout 1200 \\/' ./scripts/provisioning-tests
+sed -i 's|^go test |stdbuf -oL go test |' ./scripts/provisioning-tests
+sed -i 's| tee /tmp/out.txt| stdbuf -oL tee /tmp/out.txt|' ./scripts/provisioning-tests
+
+if [ -n "${GITHUB_ENV}" ]; then
+    echo "RANCHER_DIR=${RANCHER_DIR}" >> "${GITHUB_ENV}"
+fi
+
+# Rancher expects ~/.kube/k3s.yaml but k3s writes to /etc/rancher/k3s/k3s.yaml.
+mkdir -p "${HOME}/.kube"
+ln -sf /etc/rancher/k3s/k3s.yaml "${HOME}/.kube/k3s.yaml"
+
+export CATTLE_AGENT_IMAGE=${CATTLE_AGENT_IMAGE:-rancher/rancher-agent:v2.14-head}
+export PATH="${RANCHER_DIR}/bin:$PATH"
+
+stream_logs() {
+    set +x
+    local KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    local waited=0
+
+    while [ ! -f "$KUBECONFIG" ]; do
+        sleep 5
+        waited=$((waited + 5))
+        if [ "$waited" -ge 600 ]; then echo "[stream_logs] kubeconfig not found after 10m, giving up"; return; fi
+    done
+    while ! kubectl --kubeconfig "$KUBECONFIG" version --short >/dev/null 2>&1; do
+        sleep 5
+        waited=$((waited + 5))
+        if [ "$waited" -ge 900 ]; then echo "[stream_logs] API server not ready after 15m, giving up"; return; fi
+    done
+
+    # Cluster-wide events — image pull errors, scheduling, probes, OOM, etc.
+    kubectl --kubeconfig "$KUBECONFIG" get events -A --watch-only \
+        -o 'custom-columns=TIME:.lastTimestamp,NS:.involvedObject.namespace,KIND:.involvedObject.kind,NAME:.involvedObject.name,REASON:.reason,MESSAGE:.message' \
+        2>/dev/null | sed -u 's/^/[events] /' &
+
+    # System-agent logs from PodMachine pods as they appear.
+    while true; do
+        for pod in $(kubectl --kubeconfig "$KUBECONFIG" get pods -A -l rke.cattle.io/machine=true \
+            -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+            ns="${pod%%/*}"
+            name="${pod##*/}"
+            marker="/tmp/.sa-stream-${ns}-${name}"
+            if [ ! -f "$marker" ]; then
+                touch "$marker"
+                kubectl --kubeconfig "$KUBECONFIG" -n "$ns" exec "$name" -- \
+                    journalctl -u rancher-system-agent -f --no-pager 2>/dev/null \
+                    | sed -u "s/^/[system-agent ${name}] /" &
+            fi
+        done
+        sleep 10
+    done
+}
+
+stream_logs &
+STREAM_PID=$!
+trap 'kill -- -${STREAM_PID} 2>/dev/null || true; wait ${STREAM_PID} 2>/dev/null || true' EXIT
+
+echo "=== Starting provisioning-tests at $(date -u +'%Y-%m-%dT%H:%M:%SZ') ==="
+set -o pipefail
+./scripts/provisioning-tests 2>&1 | awk '{ printf "[%s] %s\n", strftime("%H:%M:%S", systime()), $0; fflush() }'

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -9,6 +9,9 @@ if [ "$V2PROV_TEST_DIST" != "rke2" ] && [ "$V2PROV_TEST_DIST" != "k3s" ]; then
     export V2PROV_TEST_DIST=rke2
 fi
 
+# Provisioning_MP and PreBootstrap tests live in Rancher and run there with the
+# local system-agent binary swapped in. SystemAgent tests come from this repo;
+# keep new ones named Test_SystemAgent_* so they remain covered by the default regex.
 if [ -z "${V2PROV_TEST_RUN_REGEX}" ]; then
     export V2PROV_TEST_RUN_REGEX="^Test_(Provisioning_MP|PreBootstrap|SystemAgent)_.*$"
 fi
@@ -25,6 +28,10 @@ cp "${SYSTEM_AGENT_DIR}/install.sh" /usr/share/rancher/ui/assets/system-agent-in
 source ./scripts/fetch-provisioning-tests
 
 # Copy system-agent integration tests into rancher's v2prov test tree.
+# These tests keep //go:build ignore in this repo so they do not get picked up by
+# the normal local go test package walk, but Rancher's v2prov runner expects them
+# to be regular test files once copied into its tree. Strip that line here so new
+# tests do not get silently skipped after being added.
 if compgen -G "${SYSTEM_AGENT_DIR}/test/integration/*_test.go" > /dev/null 2>&1; then
     mkdir -p "${RANCHER_DIR}/tests/v2prov/tests/systemagent"
     cp "${SYSTEM_AGENT_DIR}/test/integration/"*_test.go "${RANCHER_DIR}/tests/v2prov/tests/systemagent/"
@@ -59,6 +66,10 @@ ln -sf /etc/rancher/k3s/k3s.yaml "${HOME}/.kube/k3s.yaml"
 export CATTLE_AGENT_IMAGE=${CATTLE_AGENT_IMAGE:-rancher/rancher-agent:v2.14-head}
 export PATH="${RANCHER_DIR}/bin:$PATH"
 
+STREAM_ARTIFACT_DIR=${STREAM_ARTIFACT_DIR:-/tmp/system-agent-streams}
+rm -rf "$STREAM_ARTIFACT_DIR"
+mkdir -p "$STREAM_ARTIFACT_DIR/system-agent"
+
 stream_logs() {
     set +x
     local KUBECONFIG=/etc/rancher/k3s/k3s.yaml
@@ -78,7 +89,7 @@ stream_logs() {
     # Cluster-wide events — image pull errors, scheduling, probes, OOM, etc.
     kubectl --kubeconfig "$KUBECONFIG" get events -A --watch-only \
         -o 'custom-columns=TIME:.lastTimestamp,NS:.involvedObject.namespace,KIND:.involvedObject.kind,NAME:.involvedObject.name,REASON:.reason,MESSAGE:.message' \
-        2>/dev/null | sed -u 's/^/[events] /' &
+        2>/dev/null | sed -u 's/^/[events] /' >> "$STREAM_ARTIFACT_DIR/events.log" &
 
     # System-agent logs from PodMachine pods as they appear.
     while true; do
@@ -86,12 +97,12 @@ stream_logs() {
             -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' 2>/dev/null); do
             ns="${pod%%/*}"
             name="${pod##*/}"
-            marker="/tmp/.sa-stream-${ns}-${name}"
+            marker="$STREAM_ARTIFACT_DIR/.sa-stream-${ns}-${name}"
             if [ ! -f "$marker" ]; then
                 touch "$marker"
                 kubectl --kubeconfig "$KUBECONFIG" -n "$ns" exec "$name" -- \
                     journalctl -u rancher-system-agent -f --no-pager 2>/dev/null \
-                    | sed -u "s/^/[system-agent ${name}] /" &
+                    | sed -u "s/^/[system-agent ${name}] /" >> "$STREAM_ARTIFACT_DIR/system-agent/${ns}-${name}.log" &
             fi
         done
         sleep 10

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,8 @@
 
 The e2e test suite validates system-agent functionality in a real Kubernetes environment. Tests create a Kind cluster, deploy the system-agent as a DaemonSet, and verify various agent capabilities.
 
+See also: [integration/README.md](integration/README.md) for the v2prov-based integration test suite.
+
 ## Running Tests
 
 From the repository root:

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,64 @@
+# System Agent Integration Tests
+
+## Overview
+
+These tests exercise system-agent in Rancher's real provisioning flow by reusing the existing `tests/v2prov` framework.
+They run alongside Rancher's Machine Provisioning and pre-bootstrap coverage under the same Rancher instance, which avoids provisioning a second cluster just for system-agent coverage.
+
+This differs from the kind based [e2e suite](../README.md):
+
+- `test/e2e` validates system-agent behavior inside this repository's own test harness.
+- `test/integration` validates system-agent behavior in the Rancher provisioning flow, with real v2prov helpers and a real Rancher server.
+
+The CI entrypoint is:
+
+```bash
+make integration-tests
+```
+
+That target runs `scripts/integration-tests`, which does the following:
+
+1. Builds the `rancher-system-agent` binary from the current branch.
+2. Fetches Rancher's provisioning test tree and a Rancher binary via `scripts/fetch-provisioning-tests`.
+3. Copies this repository's integration test files into Rancher's `tests/v2prov/tests/systemagent` package.
+4. Strips the leading `//go:build ignore` line from copied tests.
+5. Patches Rancher's provisioning test script to use local system-agent artifacts instead of downloading release binaries.
+6. Runs Rancher's provisioning tests against a real Rancher instance.
+
+## Why These Tests Use `//go:build ignore`
+
+Integration tests in this directory import Rancher's `tests/v2prov` packages. Keeping those imports in this repository's normal Go module would pull in Rancher's large dependency tree and break ordinary local `go test` and build flows.
+
+To avoid that, integration tests here are intentionally kept out of the normal package walk with:
+
+```go
+//go:build ignore
+```
+
+The integration runner removes that line only after copying the tests into Rancher's module tree, where the `tests/v2prov` imports are valid.
+
+If a new integration test keeps the build tag after the copy step, Rancher's runner will silently skip it. That is why `scripts/integration-tests` strips the first `//go:build ignore` line from copied files.
+
+
+## Naming Convention
+
+The default test regex in `scripts/integration-tests` is:
+
+```bash
+^Test_(Provisioning_MP|PreBootstrap|SystemAgent)_.*$
+```
+
+That means:
+
+- `Test_Provisioning_MP_*` and `Test_PreBootstrap_*` are Rancher-owned tests that already live in the Rancher repository.
+- `Test_SystemAgent_*` are system-agent-owned tests that live in this repository and are copied into Rancher's test tree at runtime.
+
+New tests added here should use the `Test_SystemAgent_*` prefix so they are included by default.
+
+## How To Add A New Integration Test
+
+1. Add a new `*_test.go` file under `test/integration`.
+2. Start the file with `//go:build ignore`.
+3. Write the test against Rancher's `tests/v2prov` helpers, matching the existing tests in this directory.
+4. Name the test function `Test_SystemAgent_*` so it matches the default regex.
+5. Run `make integration-tests` to validate the new test in the Rancher-backed flow.

--- a/test/integration/force_apply_on_restart_test.go
+++ b/test/integration/force_apply_on_restart_test.go
@@ -1,0 +1,140 @@
+//go:build ignore
+
+package systemagent
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	provisioningv1api "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/tests/v2prov/clients"
+	"github.com/rancher/rancher/tests/v2prov/cluster"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/cluster-api/controllers/external"
+)
+
+// Test_SystemAgent_ForceApplyOnRestart provisions a single-node cluster,
+// restarts system-agent, and verifies:
+//  1. last-apply-time in the plan secret changes (proving the hasRunOnce
+//     force-reapply logic in k8splan/watcher.go fired).
+//  2. The cluster remains Ready (proving reconnection works).
+func Test_SystemAgent_ForceApplyOnRestart(t *testing.T) {
+	t.Log("creating v2prov clients")
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	t.Log("creating single-node all-roles cluster")
+	c, err := cluster.New(clients, &provisioningv1api.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-systemagent-force-apply-restart",
+		},
+		Spec: provisioningv1api.ClusterSpec{
+			KubernetesVersion: defaults.SomeK8sVersion,
+			RKEConfig: &provisioningv1api.RKEConfig{
+				MachinePools: []provisioningv1api.RKEMachinePool{{
+					EtcdRole:         true,
+					ControlPlaneRole: true,
+					WorkerRole:       true,
+					Quantity:         &defaults.One,
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("waiting for cluster to become ready (this may take several minutes)")
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("cluster %s/%s is ready", c.Namespace, c.Name)
+
+	t.Log("listing CAPI machines")
+	machines, err := cluster.Machines(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(machines.Items) != 1 {
+		t.Fatalf("expected 1 machine, got %d", len(machines.Items))
+	}
+
+	machine := machines.Items[0]
+	planSecretName := capr.PlanSecretFromBootstrapName(machine.Spec.Bootstrap.ConfigRef.Name)
+
+	t.Logf("recording pre-restart last-apply-time from plan secret %s/%s", machine.Namespace, planSecretName)
+	secret, err := clients.Core.Secret().Get(machine.Namespace, planSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("plan secret not found: %v", err)
+	}
+	preRestartTime := string(secret.Data[lastApplyTimeKey])
+	t.Logf("pre-restart last-apply-time: %s", preRestartTime)
+
+	t.Log("resolving PodMachine pod for system-agent restart")
+	im, err := external.GetObjectFromContractVersionedRef(clients.Ctx, clients.Client,
+		machine.Spec.InfrastructureRef, machine.Namespace)
+	if err != nil {
+		t.Fatalf("failed to get infra machine: %v", err)
+	}
+
+	podName := strings.ReplaceAll(im.GetName(), ".", "-")
+	podNamespace := im.GetNamespace()
+	t.Logf("restarting rancher-system-agent in pod %s/%s", podNamespace, podName)
+
+	cmd := exec.Command("kubectl", "-n", podNamespace, "exec", podName, "--",
+		"systemctl", "restart", "rancher-system-agent")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to restart system-agent: %v\noutput: %s", err, string(out))
+	}
+	t.Log("systemctl restart succeeded, polling plan secret for updated last-apply-time")
+
+	// Poll until last-apply-time changes — this proves hasRunOnce triggered
+	// a force-reapply after the restart.
+	ctx, cancel := context.WithTimeout(clients.Ctx, 3*time.Minute)
+	defer cancel()
+
+	err = wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		s, err := clients.Core.Secret().Get(machine.Namespace, planSecretName, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("poll: error reading plan secret (will retry): %v", err)
+			return false, nil
+		}
+		current := string(s.Data[lastApplyTimeKey])
+		if current != preRestartTime && current != "" {
+			t.Logf("poll: last-apply-time changed to %s (was %s)", current, preRestartTime)
+			return true, nil
+		}
+		t.Logf("poll: last-apply-time still %s, waiting...", current)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("last-apply-time did not change within 3 minutes after restart: %v", err)
+	}
+
+	t.Log("waiting for cluster to converge back to ready after restart")
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("cluster still ready after system-agent restart")
+
+	t.Log("deleting cluster and waiting for cleanup")
+	if err := clients.Provisioning.Cluster().Delete(c.Namespace, c.Name, &metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = cluster.WaitForDelete(clients, c); err != nil {
+		t.Fatal(err)
+	}
+	t.Log("cluster deleted successfully")
+}

--- a/test/integration/plan_secret_status_test.go
+++ b/test/integration/plan_secret_status_test.go
@@ -1,0 +1,131 @@
+//go:build ignore
+
+package systemagent
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	provisioningv1api "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/rancher/pkg/capr"
+	"github.com/rancher/rancher/tests/v2prov/clients"
+	"github.com/rancher/rancher/tests/v2prov/cluster"
+	"github.com/rancher/rancher/tests/v2prov/defaults"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Plan secret data keys written by system-agent's k8splan watcher.
+// These match the constants in pkg/k8splan/watcher.go.
+const (
+	appliedChecksumKey = "applied-checksum"
+	failedChecksumKey  = "failed-checksum"
+	failureCountKey    = "failure-count"
+	lastApplyTimeKey   = "last-apply-time"
+	successCountKey    = "success-count"
+)
+
+// Test_SystemAgent_PlanSecretStatus provisions a single-node cluster and
+// verifies that system-agent populated the plan secret with the expected
+// status keys. This directly exercises the k8splan watcher's updateSecret
+// path — the core feedback loop between system-agent and Rancher.
+func Test_SystemAgent_PlanSecretStatus(t *testing.T) {
+	t.Log("creating v2prov clients")
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	t.Log("creating single-node all-roles cluster")
+	c, err := cluster.New(clients, &provisioningv1api.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-systemagent-plan-secret-status",
+		},
+		Spec: provisioningv1api.ClusterSpec{
+			KubernetesVersion: defaults.SomeK8sVersion,
+			RKEConfig: &provisioningv1api.RKEConfig{
+				MachinePools: []provisioningv1api.RKEMachinePool{{
+					EtcdRole:         true,
+					ControlPlaneRole: true,
+					WorkerRole:       true,
+					Quantity:         &defaults.One,
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("waiting for cluster to become ready (this may take several minutes)")
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("cluster %s/%s is ready", c.Namespace, c.Name)
+
+	t.Log("listing CAPI machines")
+	machines, err := cluster.Machines(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(machines.Items) != 1 {
+		t.Fatalf("expected 1 machine, got %d", len(machines.Items))
+	}
+
+	machine := machines.Items[0]
+	planSecretName := capr.PlanSecretFromBootstrapName(machine.Spec.Bootstrap.ConfigRef.Name)
+
+	t.Logf("inspecting plan secret %s/%s for system-agent status keys", machine.Namespace, planSecretName)
+	secret, err := clients.Core.Secret().Get(machine.Namespace, planSecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("plan secret not found: %v", err)
+	}
+
+	// applied-checksum must be non-empty: system-agent writes it after
+	// successfully applying the plan (k8splan/watcher.go).
+	if v := string(secret.Data[appliedChecksumKey]); v == "" {
+		t.Error("applied-checksum is empty — system-agent did not write it back")
+	} else {
+		t.Logf("applied-checksum: %s", v)
+	}
+
+	// success-count must be >= 1 after a successful bootstrap.
+	if raw, ok := secret.Data[successCountKey]; !ok || len(raw) == 0 {
+		t.Error("success-count missing or empty")
+	} else if n, err := strconv.Atoi(string(raw)); err != nil || n < 1 {
+		t.Errorf("success-count should be >= 1, got %q", string(raw))
+	} else {
+		t.Logf("success-count: %d", n)
+	}
+
+	// last-apply-time must be parseable as time.UnixDate (the format
+	// system-agent uses in k8splan/watcher.go).
+	if raw, ok := secret.Data[lastApplyTimeKey]; !ok || len(raw) == 0 {
+		t.Error("last-apply-time missing or empty")
+	} else if _, err := time.Parse(time.UnixDate, string(raw)); err != nil {
+		t.Errorf("last-apply-time %q is not valid UnixDate: %v", string(raw), err)
+	} else {
+		t.Logf("last-apply-time: %s", string(raw))
+	}
+
+	// failure-count should be "0" after a successful apply.
+	if raw := secret.Data[failureCountKey]; len(raw) > 0 && string(raw) != "0" {
+		t.Errorf("failure-count should be 0 after success, got %q", string(raw))
+	}
+
+	// failed-checksum should be empty — no failures occurred.
+	if v := string(secret.Data[failedChecksumKey]); v != "" {
+		t.Errorf("failed-checksum should be empty, got %q", v)
+	}
+
+	t.Log("deleting cluster and waiting for cleanup")
+	if err := clients.Provisioning.Cluster().Delete(c.Namespace, c.Name, &metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = cluster.WaitForDelete(clients, c); err != nil {
+		t.Fatal(err)
+	}
+	t.Log("cluster deleted successfully")
+}


### PR DESCRIPTION
Adds integration tests that exercise the system-agent's k8splan watcher against a real Rancher instance using the existing v2prov provisioning-tests framework. Tests run on a GHA native runner (no Dapper) against `rancher/rancher:v2.14-head`.

**CI infra setup + scripts:**
- New GHA workflow that sets up k3s binaries, Docker with cgroupfs + insecure-registry, and runs tests via `make integration-tests`.
- `fetch-provisioning-tests` script - clones rancher/rancher, extracts the rancher binary from the container image, and tags it as `rancher/rancher:dev` so provisioning-tests skips building from source.
- `integration-tests` script - builds system-agent from the current branch, copies integration tests into rancher's v2prov test tree (stripping `//go:build ignore` tags), patches provisioning-tests to use local binaries

**Design decisions**
- Tests live in system-agent with `//go:build ignore` tags so they don't break go build here. They import `github.com/rancher/rancher/tests/v2prov` packages from rancher's root module, which would pull in the entire rancher dependency tree if added to system-agent's go.mod file. The CI script strips the build tag after copying them into Rancher's module tree.
- Tests run alongside existing v2prov **MP/prebootstrap** tests under the same Rancher instance to avoid spinning up a second cluster, keeping CI under the 2-hour timeout.
- Rancher binary is pulled from a container image rather than built from source - avoids compiling all of rancher in CI and keeps the focus on testing system-agent changes.
- Timeouts are increased from upstream defaults (300s -> 600-1200s) because GHA ubuntu-latest runners have only 2 cores, which is a limitation that most probably can be solved by reaching out to the infra team, but for the initial phase, it should be sufficient.

Two system-agent-specific integration tests added:
1. provisions a single-node cluster and validates that the system-agent correctly populates plan secret status keys 
2. provisions a cluster, restarts the system-agent via systemctl, and verifies last-apply-time changes and the cluster stays Ready.

Docs:
- A new README was added under test/integration folder which explain test architecture, answering some "why"s' and "how"s' to add new integration tests in the future.

Note: I am planning to add more integration tests in follow-up PRs if the current approach seems fine and accepted by reviewers.

Part of: #260 