### PR TITLE
export applyinator byte functions

### DIFF
--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -200,11 +200,11 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 		logrus.Infof("[Applyinator] Applying one-time instructions for plan with checksum %s", input.CalculatedPlan.Checksum)
 		executionOutputs := map[string][]byte{}
 		if len(input.ExistingOneTimeOutput) > 0 {
-			objectBuffer, err := generateByteBufferFromBytes(input.ExistingOneTimeOutput)
+			objectBuffer, err := GenerateByteBufferFromBytes(input.ExistingOneTimeOutput)
 			if err != nil {
 				return output, err
 			}
-			if err := json.Unmarshal(objectBuffer.Bytes(), &executionOutputs); err != nil {
+			if err := json.Unmarshal(objectBuffer, &executionOutputs); err != nil {
 				return output, err
 			}
 		}
@@ -237,7 +237,7 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 			return output, err
 		}
 
-		oneTimeApplyOutput, err := gzipByteSlice(marshalledExecutionOutputs)
+		oneTimeApplyOutput, err := GzipByteSlice(marshalledExecutionOutputs)
 		if err != nil {
 			return output, err
 		}
@@ -247,11 +247,11 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 
 	periodicOutputs := map[string]planapi.PeriodicInstructionOutput{}
 	if len(input.ExistingPeriodicOutput) > 0 {
-		objectBuffer, err := generateByteBufferFromBytes(input.ExistingPeriodicOutput)
+		objectBuffer, err := GenerateByteBufferFromBytes(input.ExistingPeriodicOutput)
 		if err != nil {
 			return output, err
 		}
-		if err := json.Unmarshal(objectBuffer.Bytes(), &periodicOutputs); err != nil {
+		if err := json.Unmarshal(objectBuffer, &periodicOutputs); err != nil {
 			return output, err
 		}
 	}
@@ -343,7 +343,7 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 	if err != nil {
 		return output, err
 	}
-	periodicApplyOutput, err := gzipByteSlice(marshalledExecutionOutputs)
+	periodicApplyOutput, err := GzipByteSlice(marshalledExecutionOutputs)
 	if err != nil {
 		return output, err
 	}
@@ -352,7 +352,8 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 	return output, nil
 }
 
-func gzipByteSlice(input []byte) ([]byte, error) {
+// GzipByteSlice compresses input using gzip and returns the compressed bytes.
+func GzipByteSlice(input []byte) ([]byte, error) {
 	var gzOutput bytes.Buffer
 
 	gzWriter := gzip.NewWriter(&gzOutput)
@@ -367,9 +368,9 @@ func gzipByteSlice(input []byte) ([]byte, error) {
 	return gzOutput.Bytes(), nil
 }
 
-func generateByteBufferFromBytes(input []byte) (*bytes.Buffer, error) {
-	buffer := bytes.NewBuffer(input)
-	gzReader, err := gzip.NewReader(buffer)
+// GenerateByteBufferFromBytes decompresses gzip-compressed input and returns the raw bytes.
+func GenerateByteBufferFromBytes(input []byte) ([]byte, error) {
+	gzReader, err := gzip.NewReader(bytes.NewBuffer(input))
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +380,7 @@ func generateByteBufferFromBytes(input []byte) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &objectBuffer, nil
+	return objectBuffer.Bytes(), nil
 }
 
 func (a *Applyinator) appliedPlanRetentionPolicy(retention int) error {

--- a/test/framework/decode.go
+++ b/test/framework/decode.go
@@ -16,13 +16,12 @@ package framework
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 
 	planapi "github.com/rancher/rancher/pkg/plan"
+	"github.com/rancher/system-agent/pkg/applyinator"
 )
 
 // DecodeOutput decodes a gzip-compressed output,
@@ -35,13 +34,7 @@ func DecodeOutput(encoded []byte) (string, error) {
 	}
 
 	// Step 1: Decompress gzip
-	reader, err := gzip.NewReader(bytes.NewReader(encoded))
-	if err != nil {
-		return "", err
-	}
-	defer reader.Close()
-
-	gzipResult, err := io.ReadAll(reader)
+	gzipResult, err := applyinator.GenerateByteBufferFromBytes(encoded)
 	if err != nil {
 		return "", err
 	}
@@ -77,13 +70,7 @@ func GetOutputMap(encoded []byte) (map[string]string, error) {
 		return nil, nil
 	}
 
-	reader, err := gzip.NewReader(bytes.NewReader(encoded))
-	if err != nil {
-		return nil, err
-	}
-	defer reader.Close()
-
-	gzipResult, err := io.ReadAll(reader)
+	gzipResult, err := applyinator.GenerateByteBufferFromBytes(encoded)
 	if err != nil {
 		return nil, err
 	}
@@ -112,13 +99,7 @@ func DecodePeriodicOutput(encoded []byte) (map[string]planapi.PeriodicInstructio
 		return nil, nil
 	}
 
-	reader, err := gzip.NewReader(bytes.NewReader(encoded))
-	if err != nil {
-		return nil, err
-	}
-	defer reader.Close()
-
-	gzipResult, err := io.ReadAll(reader)
+	gzipResult, err := applyinator.GenerateByteBufferFromBytes(encoded)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

The e2e test framework added in rancher/system-agent#259 introduced `test/framework/decode.go`, which re-implements that same gzip+base64+JSON encoding/decoding logic directly in test code (`GetOutputMap`, `DecodePeriodicOutput`). As noted [here](https://github.com/rancher/system-agent/pull/259#discussion_r2883677551), this means the tests are using a parallel implementation of the encoding/decoding logic. If the production encoding logic ever changes, the tests could silently diverge and continue to pass while verifying incorrect behavior.

By exporting the existing functions, they can be re-used and properly tested.