### PR TITLE
add release branches to renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,9 @@
   "extends": [
     "github>rancher/renovate-config#release"
   ],
-  "baseBranches": [
-    "main"
+  "baseBranchPatterns": [
+      "$default",
+      "/^release\\/.*/"
   ],
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
This is just so renovate runs against the new release branches.
