### PR TITLE
Ignore the deprecated 'release/v0.3' branch in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,8 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranchPatterns": [
-      "$default",
-      "/^release\\/.*/"
+    "$default",
+    "/^release\\/(?!v0\\.3$).*/"
   ],
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
There is no need to generate PRs for bumping dependencies in the deprecated 'release/v0.3' branch.
This PR updates the branch pattern to match any string that starts with the word `release/`, except if that version is exactly v0.3.