### PR TITLE
set explicit renovate branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
   ],
   "baseBranchPatterns": [
       "$default",
-      "/^release\\/.*/"
+      "release/v2.13",
+      "release/v2.14"
   ],
   "prHourlyLimit": 2
 }

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ Note that only the **minor** versions are aligned — patch versions are increme
 
 The `main` branch is used to cut releases for the most current minor release line. For previous release lines, dedicated branches are created following the pattern `release/v0.<minor>` (e.g., `release/v0.14`).
 
+Note that `renovate.json` hardcodes the branches targeted by Renovate. New branches should be added to this configuration file (and deprecated ones removed).
+
 ## Building
 
 `make`
 
 ### Cross Compiling
 
-You can also 
+You can also
 
 `CROSS=true make` if you want cross-compiled binaries for Darwin/Windows.
 
@@ -37,6 +39,7 @@ First, configure the agent by looking at the `examples/configuration` folder, th
 `./bin/rancher-system-agent`
 
 ## License
+
 Copyright (c) 2021 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
# Description

Renovate is creating PRs for all release branches, including old ones like `release/v0.3`. This PR explicitly configures the target branches.

We could have a dynamic configuration with a more complex regular expression but I think we can just add one when a new branch is created, as it doesn't happen that often (`rancher/rancher` seems to do the same).