### PR TITLE
add uninstall flag

### DIFF
--- a/package/suc/run.sh
+++ b/package/suc/run.sh
@@ -55,7 +55,12 @@ if [ -s /host/etc/systemd/system/rancher-system-agent.env ]; then
   done
 fi
 
-chroot /host ${TMPDIR}/install.sh "$@" &
+RUN_SCRIPT=${TMPDIR}/install.sh
+if [ "${UNINSTALL}" = "true" ]; then
+    RUN_SCRIPT=${TMPDIR}/rancher-system-agent-uninstall.sh
+fi
+
+chroot /host "${RUN_SCRIPT}" "$@" &
 # wait on the install script to free up trap handling
 # ref: https://www.gnu.org/software/bash/manual/html_node/Signals.html#Signals-1
 # removal of the above chroot process will occur during cgroup cleanup


### PR DESCRIPTION
## Issue:
  https://github.com/rancher/rancher/issues/55942

  ## Problem

  Rancher needs a way to run system-agent uninstall through a System Upgrade Controller plan.

  Today the SUC entrypoint in `package/suc/run.sh` always runs `install.sh`. Because of that, the same SUC image cannot be used to trigger uninstall on the node.

  ## Solution

  Add a small dispatch step in `package/suc/run.sh`.

  The script now:
  - keeps `install.sh` as the default path
  - switches to `rancher-system-agent-uninstall.sh` when `UNINSTALL=true`

  This keeps the current install and update behavior unchanged and reuses the existing uninstall script for the host-side cleanup.

  ## Testing

  ## Engineering Testing
  ### Manual Testing

  Built and pushed the SUC image with this change for downstream testing.

  Validated the branch diff and confirmed the SUC entrypoint now selects the uninstall script when `UNINSTALL=true` is present.

  ### Automated Testing

  * Test types added/modified:
      * None
  * If "None" - Reason: Lack of a suitable existing framework in this repo for focused testing of this SUC shell dispatch change
  * If "None" - GH Issue/PR: N/A

  Summary: Manual validation only. No automated tests were added in this PR.
