### PR TITLE
fix: Skip proxy vars in SUC env resurrection so deletion propagates

### DIFF
--- a/package/suc/run.sh
+++ b/package/suc/run.sh
@@ -45,14 +45,26 @@ export CATTLE_AGENT_UNINSTALL_LOCAL=true
 export CATTLE_AGENT_BINARY_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent
 export CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent-uninstall.sh
 if [ -s /host/etc/systemd/system/rancher-system-agent.env ]; then
-  for line in $(grep -v '^#' /host/etc/systemd/system/rancher-system-agent.env); do
+  while IFS= read -r line; do
+    case "$line" in
+      '#'*|'') continue ;;
+    esac
     var=${line%%=*}
-    val=${line##*=}
+    val=${line#*=}
+    # only handle well-formed shell identifiers (guards the eval below)
+    case "$var" in
+      ''|[!A-Za-z_]*|*[!A-Za-z0-9_]*) continue ;;
+    esac
+    # skip proxy vars: Rancher delivers them declaratively via the SUC plan env,
+    # so resurrecting them from the old file would defeat deletion (SURE-6828).
+    case "$var" in
+      HTTP_PROXY|HTTPS_PROXY|NO_PROXY|http_proxy|https_proxy|no_proxy) continue ;;
+    esac
     eval v=\"\$$var\"
     if [ -z "$v" ]; then
       export "$var=$val"
     fi
-  done
+  done < /host/etc/systemd/system/rancher-system-agent.env
 fi
 
 RUN_SCRIPT=${TMPDIR}/install.sh

--- a/package/suc/run.sh
+++ b/package/suc/run.sh
@@ -44,16 +44,6 @@ export CATTLE_AGENT_BINARY_LOCAL=true
 export CATTLE_AGENT_UNINSTALL_LOCAL=true
 export CATTLE_AGENT_BINARY_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent
 export CATTLE_AGENT_UNINSTALL_LOCAL_LOCATION=${TMPDIR}/rancher-system-agent-uninstall.sh
-if [ -s /host/etc/systemd/system/rancher-system-agent.env ]; then
-  for line in $(grep -v '^#' /host/etc/systemd/system/rancher-system-agent.env); do
-    var=${line%%=*}
-    val=${line##*=}
-    eval v=\"\$$var\"
-    if [ -z "$v" ]; then
-      export "$var=$val"
-    fi
-  done
-fi
 
 RUN_SCRIPT=${TMPDIR}/install.sh
 if [ "${UNINSTALL}" = "true" ]; then


### PR DESCRIPTION
## Problem

Deleting an agent env var (`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`) on a downstream cluster doesn't propagate — the old value  persists in `/etc/systemd/system/rancher-system-agent.env`.

Fixes SURE-6828 / rancher/rancher#45210

## Cause

`package/suc/run.sh` re-exports vars from the existing env file before running `install.sh`. On delete, the plan correctly omits the var, but the loop resurrects the stale value from the old file and `create_env_file` writes it back.

## Fix

Skip proxy vars in the loop so the SUC plan env is the source of truth (present → written, absent → cleared). `PATH` and
other vars still preserved. Also fix `${line##*=}` → `${line#*=}` for values containing `=`.

## Testing

Set → update → delete `NO_PROXY` on a downstream cluster with the patched `-suc` image: value now clears on delete. No regression for set/update/no-proxy cases.
