### PR TITLE
skip removing the temp connection info file when something goes wrong and let the user know to check there for more info

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -805,13 +805,13 @@ retrieve_connection_info() {
                 if ! "${CATTLE_AGENT_BIN_PREFIX}/bin/rancher-system-agent" validate-connection "${TEMP_CONNECTION_INFO}" 2>&1; then
                     i=$((i + 1))
                     error "Downloaded connection info failed validation. Sleeping for 5 seconds and trying again"
-                    rm -f "${TEMP_CONNECTION_INFO}"
                     sleep 5
                     continue
                 fi
 
                 # Move temp file to final location
                 mv "${TEMP_CONNECTION_INFO}" "${CATTLE_AGENT_VAR_DIR}/rancher2_connection_info.json"
+                rm -f "${TEMP_CONNECTION_INFO}"
 
                 info "Successfully downloaded and validated Rancher connection information"
                 umask "${UMASK}"
@@ -819,8 +819,8 @@ retrieve_connection_info() {
                 ;;
             *)
                 i=$((i + 1))
-                error "$RESPONSE received while downloading Rancher connection information. Sleeping for 5 seconds and trying again"
-                rm -f "${TEMP_CONNECTION_INFO}"
+                # urge the user to check the temp file rather than printing direct to stdout/journal
+                error "$RESPONSE received while downloading Rancher connection information. Sleeping for 5 seconds and trying again. Check $TEMP_CONNECTION_INFO for response"
                 sleep 5
                 continue
                 ;;


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56013
### Followup of https://github.com/rancher/rancher/pull/56229

Currently (and in past releases) when something goes wrong on the Rancher side (some component being not-available in Rancher whether its capi, apiextensions, webhook etc being unavailable) we download the connection info to a temp file and then clean up since something did technically go wrong. 

In an effort to improve visibility, lets just leave that file hanging around and let the user know to look there for the error message. This combined with Rancher hopefully spamming logs a bit more that something is wrong with this particular endpoint should help troubleshoot when things are not healthy in the Rancher install.
