### PR TITLE
Add packageRules to renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,26 @@
   ],
   "baseBranchPatterns": [
       "$default",
-      "/^release\\/.*/"
+      "release/v2.14",
+      "release/v2.13"
+  ],
+  "packageRules": [
+    {
+      "matchBaseBranches": [
+        "release/v2.14"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.14#release"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "release/v2.13"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.13#release"
+      ]
+    }
   ],
   "prHourlyLimit": 2
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,19 @@
   ],
   "baseBranchPatterns": [
       "$default",
+      "release/v2.15",
       "release/v2.14",
       "release/v2.13"
   ],
   "packageRules": [
+    {
+      "matchBaseBranches": [
+        "release/v2.15"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.15#release"
+      ]
+    },
     {
       "matchBaseBranches": [
         "release/v2.14"


### PR DESCRIPTION
to properly restrict updates for release branches. Also define specific release branches, so `release/v0.3` does not get update and new release branches are not treated like a branch without package rules.