### PR TITLE
self heal interlock file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -592,6 +592,7 @@ RestartSec=5s
 Environment=CATTLE_LOGLEVEL=${CATTLE_AGENT_LOGLEVEL}
 Environment=CATTLE_AGENT_CONFIG=${CATTLE_AGENT_CONFIG_DIR}/config.yaml
 Environment=CATTLE_AGENT_STRICT_VERIFY=${CATTLE_AGENT_STRICT_VERIFY}
+ExecStartPre=-/bin/rm -f ${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active
 ExecStart=${CATTLE_AGENT_BIN_PREFIX}/bin/rancher-system-agent sentinel
 EOF
 
@@ -908,16 +909,24 @@ create_env_file() {
 }
 
 ensure_applyinator_not_active() {
+    FILE_APPLYINATOR="${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active"
     i=1
     while [ "${i}" -ne "${APPLYINATOR_ACTIVE_WAIT_COUNT}" ]; do
-      if [ -f "${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active" ]; then
+        [ -f "${FILE_APPLYINATOR}" ] || return 0
+        # The agent stamps this file with its pid. If that process is gone the file
+        # is a leftover, so there is nothing to wait for.
+        _pid=$(sed -n 's/^pid=//p' "${FILE_APPLYINATOR}" 2>/dev/null | head -1)
+        if [ -n "${_pid}" ] && ! kill -0 "${_pid}" 2>/dev/null; then
+            info "Active plan interlock owned by pid ${_pid}, which is no longer running. Removing stale interlock file."
+            rm -f "${FILE_APPLYINATOR}"
+            return 0
+        fi
         i=$((i + 1))
         info "Active plan reconciliation detected. Sleeping for 5 seconds and retrying check"
         sleep 5
-        continue
-      fi
-      break
     done
+    warn "Ignoring active plan interlock ${FILE_APPLYINATOR} after timeout; removing it."
+    rm -f "${FILE_APPLYINATOR}"
 }
 
 do_install() {

--- a/pkg/applyinator/apply_interlock_test.go
+++ b/pkg/applyinator/apply_interlock_test.go
@@ -1,0 +1,257 @@
+package applyinator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	planapi "github.com/rancher/rancher/pkg/plan"
+)
+
+// testEnv bundles an Applyinator with the paths the interlock tests assert on.
+type testEnv struct {
+	a *Applyinator
+	// active and restartPending are the two interlock files.
+	active         string
+	restartPending string
+	// appliedPlanDir receives a "<datecode>-applied.plan" file once Apply gets
+	// past the interlock gate. Unlike executing an instruction, writing it does
+	// not require root, so it is the signal these tests use for "Apply
+	// proceeded".
+	appliedPlanDir string
+}
+
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	interlockDir := t.TempDir()
+	appliedPlanDir := t.TempDir()
+	return &testEnv{
+		a:              NewApplyinator(t.TempDir(), false, appliedPlanDir, interlockDir, nil),
+		active:         filepath.Join(interlockDir, applyinatorActiveInterlockFile),
+		restartPending: filepath.Join(interlockDir, restartPendingInterlockFile),
+		appliedPlanDir: appliedPlanDir,
+	}
+}
+
+// apply runs a minimal plan. One-time instructions are deliberately not run:
+// executing one chowns the working directory to root, which unprivileged test
+// runners cannot do, and the interlock gate gets no say in what runs afterwards.
+func (e *testEnv) apply(t *testing.T) (ApplyOutput, error) {
+	t.Helper()
+	return e.a.Apply(context.Background(), ApplyInput{
+		CalculatedPlan: CalculatedPlan{Checksum: "testchecksum"},
+	})
+}
+
+func (e *testEnv) planWasApplied(t *testing.T) bool {
+	t.Helper()
+	entries, err := os.ReadDir(e.appliedPlanDir)
+	if err != nil {
+		t.Fatalf("unable to read applied plan dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), appliedPlanFileSuffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// assertProceeded asserts Apply got past the interlock gate.
+func (e *testEnv) assertProceeded(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Apply returned an unexpected error: %v", err)
+	}
+	if !e.planWasApplied(t) {
+		t.Error("Apply returned nil but never reached the apply stage")
+	}
+}
+
+// assertBlocked asserts Apply refused, with an error mentioning want, and never
+// reached the apply stage.
+func (e *testEnv) assertBlocked(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("Apply returned nil error, want it to be blocked by an interlock")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %v, want it to contain %q", err, want)
+	}
+	if e.planWasApplied(t) {
+		t.Error("Apply reached the apply stage despite being blocked")
+	}
+}
+
+func writeOwner(t *testing.T, path string, o interlockOwner) {
+	t.Helper()
+	if err := os.WriteFile(path, o.marshal(), 0600); err != nil {
+		t.Fatalf("unable to write interlock file %s: %v", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path, what string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("%s: expected %s to be gone, stat err = %v", what, path, err)
+	}
+}
+
+func mustExist(t *testing.T, path, what string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("%s: expected %s to still exist, stat err = %v", what, path, err)
+	}
+}
+
+func liveOwner(t *testing.T) interlockOwner {
+	t.Helper()
+	pid := spawnLiveProcess(t)
+	return interlockOwner{PID: pid, BootID: currentBootID(), Start: procStartTime(pid), Written: time.Now()}
+}
+
+func deadOwner(t *testing.T) interlockOwner {
+	t.Helper()
+	return interlockOwner{PID: spawnDeadPID(t), BootID: currentBootID(), Written: time.Now()}
+}
+
+// TestApplyRemovesStaleActiveInterlock is the direct regression test for the
+// wrong-path stat: before the fix Apply looked for a bare "applyinator-active"
+// relative to the working directory (systemd supplies "/"), so a leaked file was
+// never cleared and every subsequent install.sh burned five minutes on it.
+func TestApplyRemovesStaleActiveInterlock(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.active, deadOwner(t))
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "stale interlock from a dead owner")
+}
+
+// TestApplyRefusesWhenActiveInterlockOwnerAlive is the counterweight: the new
+// liveness check must not become a licence to trample a genuinely concurrent
+// apply. A false negative here means two agents applying plans at once.
+func TestApplyRefusesWhenActiveInterlockOwnerAlive(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.active, liveOwner(t))
+
+	_, err := e.apply(t)
+	e.assertBlocked(t, err, "refusing to apply concurrently")
+	mustExist(t, e.active, "live holder's interlock must not be deleted")
+}
+
+// TestApplyRemovesActiveInterlockAfterReboot: a PID may well be live after a
+// reboot, belonging to something else entirely.
+func TestApplyRemovesActiveInterlockAfterReboot(t *testing.T) {
+	if currentBootID() == "" {
+		t.Skip("boot id unavailable on this system")
+	}
+	e := newTestEnv(t)
+	owner := liveOwner(t)
+	owner.BootID = "00000000-0000-0000-0000-000000000000"
+	writeOwner(t, e.active, owner)
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "interlock from a previous boot")
+}
+
+// TestApplyRemovesActiveInterlockOnPIDReuse covers a recycled PID within a single
+// boot, which the boot id cannot catch.
+func TestApplyRemovesActiveInterlockOnPIDReuse(t *testing.T) {
+	e := newTestEnv(t)
+	owner := liveOwner(t)
+	if owner.Start == 0 {
+		t.Skip("/proc start time unavailable on this system")
+	}
+	owner.Start++ // a different process wearing this PID
+	writeOwner(t, e.active, owner)
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "interlock whose owner's start time does not match")
+}
+
+// TestApplyRemovesLegacyActiveInterlock covers a new binary meeting a file
+// written by an older install.sh (bare touch) or an older agent (bare timestamp).
+func TestApplyRemovesLegacyActiveInterlock(t *testing.T) {
+	for _, tc := range []struct{ name, contents string }{
+		{"empty file from a legacy touch", ""},
+		{"bare timestamp from an older agent", time.Now().Format(time.UnixDate)},
+		{"unrecognised junk", "garbage\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestEnv(t)
+			if err := os.WriteFile(e.active, []byte(tc.contents), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := e.apply(t)
+			e.assertProceeded(t, err)
+			mustNotExist(t, e.active, "legacy interlock")
+		})
+	}
+}
+
+// TestApplyClearsItsOwnInterlock: the deferred cleanup on the happy path.
+func TestApplyClearsItsOwnInterlock(t *testing.T) {
+	e := newTestEnv(t)
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "interlock after a completed apply")
+}
+
+// TestApplyWritesOwnerStampedInterlockWhileRunning proves the file exists while
+// the plan is running and carries this process's identity. It needs a plan that
+// actually executes, and executing an instruction chowns the working directory
+// to root.
+func TestApplyWritesOwnerStampedInterlockWhileRunning(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("executing an instruction chowns the working directory to root; run as root to cover this")
+	}
+	e := newTestEnv(t)
+	captured := filepath.Join(t.TempDir(), "captured")
+
+	out, err := e.a.Apply(context.Background(), ApplyInput{
+		CalculatedPlan: CalculatedPlan{
+			Checksum: "testchecksum",
+			Plan: planapi.Plan{
+				OneTimeInstructions: []planapi.OneTimeInstruction{{
+					CommonInstruction: planapi.CommonInstruction{
+						Name:    "capture",
+						Command: "/bin/sh",
+						Args:    []string{"-c", "cat " + e.active + " > " + captured},
+					},
+				}},
+			},
+		},
+		RunOneTimeInstructions: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply returned an unexpected error: %v", err)
+	}
+	if !out.OneTimeApplySucceeded {
+		t.Fatal("plan did not run, so the interlock was never captured")
+	}
+
+	contents, err := os.ReadFile(captured)
+	if err != nil {
+		t.Fatalf("interlock file did not exist while the plan was running: %v", err)
+	}
+	owner, ok := parseInterlockOwner(contents)
+	if !ok {
+		t.Fatalf("interlock written during apply is not owner-stamped: %q", contents)
+	}
+	if owner.PID != os.Getpid() {
+		t.Errorf("interlock pid = %d, want this process %d", owner.PID, os.Getpid())
+	}
+	if owner.BootID != currentBootID() {
+		t.Errorf("interlock boot id = %q, want %q", owner.BootID, currentBootID())
+	}
+	if want := procStartTime(os.Getpid()); want != 0 && owner.Start != want {
+		t.Errorf("interlock start = %d, want %d", owner.Start, want)
+	}
+	mustNotExist(t, e.active, "interlock after a completed apply")
+}

--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -107,10 +107,15 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 	if a.interlockDir != "" {
 		restartPendingInterlockFilePath := filepath.Join(a.interlockDir, restartPendingInterlockFile)
 		applyinatorActiveInterlockFilePath := filepath.Join(a.interlockDir, applyinatorActiveInterlockFile)
-		// First off, remove check and remove the active interlock as the applyinator is not actually active
-		if _, err := os.Stat(applyinatorActiveInterlockFile); err == nil {
-			err = os.Remove(applyinatorActiveInterlockFile)
-			if err != nil {
+		// First off, check and remove the active interlock as the applyinator is not actually active.
+		// The file is only meaningful while its writer is still running: this process is the only
+		// thing that creates it, so anything found here was left by an agent that no longer exists.
+		if contents, err := os.ReadFile(applyinatorActiveInterlockFilePath); err == nil {
+			if owner, ok := parseInterlockOwner(contents); ok && owner.PID != os.Getpid() && owner.isAlive() {
+				return output, fmt.Errorf("another system-agent process (pid %d) is applying a plan; refusing to apply concurrently", owner.PID)
+			}
+			logrus.Warnf("[Applyinator] removing stale active interlock file %s left by a previous agent", applyinatorActiveInterlockFilePath)
+			if err := os.Remove(applyinatorActiveInterlockFilePath); err != nil && !os.IsNotExist(err) {
 				logrus.Errorf("unable to remove applyinator active interlock file %s: %v", applyinatorActiveInterlockFilePath, err)
 			}
 		}
@@ -141,7 +146,7 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 		}
 
 		// At this point, there is no restart-pending and we can continue with applyinator reconciliation, so create the applyinator-active file
-		err := os.WriteFile(applyinatorActiveInterlockFilePath, []byte(nowUnixTimeString), 0600)
+		err := os.WriteFile(applyinatorActiveInterlockFilePath, newInterlockOwner(now).marshal(), 0600)
 		if err != nil {
 			logrus.Errorf("unable to write applyinator active interlock file %s: %v", applyinatorActiveInterlockFilePath, err)
 		}

--- a/pkg/applyinator/installsh_test.go
+++ b/pkg/applyinator/installsh_test.go
@@ -1,0 +1,164 @@
+package applyinator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// installShPath is the installer whose interlock handling must stay in step with
+// this package. The two write and read the same on-disk format, in two
+// languages, with no shared definition — so it is pinned by test.
+const installShPath = "../../install.sh"
+
+// runInstallShFunc evaluates install.sh up to (but not including) do_install,
+// which defines its helper functions without running the installer, then invokes
+// the given snippet. Returns combined output.
+func runInstallShFunc(t *testing.T, env []string, snippet string) (string, error) {
+	t.Helper()
+	if _, err := os.Stat(installShPath); err != nil {
+		t.Skipf("install.sh not found at %s: %v", installShPath, err)
+	}
+	abs, err := filepath.Abs(installShPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	harness := fmt.Sprintf(`
+set -e
+eval "$(sed '/^do_install/,$d' %q)"
+%s
+`, abs, snippet)
+
+	cmd := exec.Command("sh", "-c", harness)
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// TestInstallShEnsureApplyinatorNotActiveDeadOwner: the five-minute wait was the
+// user-visible cost of the leaked interlock. A dead owner must short-circuit it.
+func TestInstallShEnsureApplyinatorNotActiveDeadOwner(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(dir, "interlock", "applyinator-active")
+	writeOwner(t, active, deadOwner(t))
+
+	start := time.Now()
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"ensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("took %v; a dead owner must not be waited on", elapsed)
+	}
+	if !strings.Contains(out, "no longer running") {
+		t.Errorf("expected the stale-owner message, got:\n%s", out)
+	}
+	mustNotExist(t, active, "stale interlock after ensure_applyinator_not_active")
+}
+
+func TestInstallShEnsureApplyinatorNotActiveNoFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"ensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("took %v; with no interlock file it must return immediately", elapsed)
+	}
+	if strings.Contains(out, "Active plan reconciliation detected") {
+		t.Errorf("slept despite there being no interlock file:\n%s", out)
+	}
+}
+
+// TestInstallShEnsureApplyinatorNotActiveLiveOwner: a genuinely running apply
+// must still be waited on, and the wait must still terminate.
+func TestInstallShEnsureApplyinatorNotActiveLiveOwner(t *testing.T) {
+	if testing.Short() {
+		t.Skip("takes ~5s waiting on the live owner")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(dir, "interlock", "applyinator-active")
+	writeOwner(t, active, liveOwner(t))
+
+	// Two iterations rather than the production 60, to keep the test to one sleep.
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"APPLYINATOR_ACTIVE_WAIT_COUNT=2\nensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Active plan reconciliation detected") {
+		t.Errorf("expected it to wait on the live owner, got:\n%s", out)
+	}
+	if !strings.Contains(out, "after timeout") {
+		t.Errorf("expected the timeout message, got:\n%s", out)
+	}
+	mustNotExist(t, active, "interlock after the wait timed out")
+}
+
+// TestInstallShEnsureApplyinatorNotActiveLegacyFile: an empty file from an older
+// install.sh carries no PID, so the installer cannot test liveness and must fall
+// back to waiting out the timeout rather than deleting a possibly-live holder's
+// interlock immediately.
+func TestInstallShEnsureApplyinatorNotActiveLegacyFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("takes ~5s waiting out the timeout")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(dir, "interlock", "applyinator-active")
+	if err := os.WriteFile(active, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"APPLYINATOR_ACTIVE_WAIT_COUNT=2\nensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Active plan reconciliation detected") {
+		t.Errorf("expected it to wait on a legacy file with no pid, got:\n%s", out)
+	}
+	mustNotExist(t, active, "legacy interlock after the wait timed out")
+}
+
+// TestInstallShServiceUnitClearsInterlock pins the ExecStartPre backstop. It is
+// what covers a recycled PID across an agent restart, so its absence would be a
+// silent regression.
+func TestInstallShServiceUnitClearsInterlock(t *testing.T) {
+	contents, err := os.ReadFile(installShPath)
+	if err != nil {
+		t.Skipf("install.sh not readable: %v", err)
+	}
+	unit := string(contents)
+	if !strings.Contains(unit, "ExecStartPre=-/bin/rm -f ${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active") {
+		t.Error("the generated systemd unit no longer clears applyinator-active before starting the agent")
+	}
+	// The leading "-" makes a missing /bin/rm non-fatal for the unit.
+	if !strings.Contains(unit, "ExecStartPre=-") {
+		t.Error("ExecStartPre is not prefixed with '-', so a missing /bin/rm would fail the unit")
+	}
+}

--- a/pkg/applyinator/interlock.go
+++ b/pkg/applyinator/interlock.go
@@ -1,0 +1,129 @@
+package applyinator
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const bootIDPath = "/proc/sys/kernel/random/boot_id"
+
+// interlockOwner identifies the process that created an interlock file, so a
+// later process can distinguish a live holder from one that was killed.
+type interlockOwner struct {
+	PID     int
+	BootID  string
+	Written time.Time
+	Start   uint64
+}
+
+func newInterlockOwner(now time.Time) interlockOwner {
+	pid := os.Getpid()
+	return interlockOwner{PID: pid, BootID: currentBootID(), Start: procStartTime(pid), Written: now}
+}
+
+// procStartTime returns field 22 of /proc/<pid>/stat — the process start time in
+// clock ticks since boot. Zero means unavailable, in which case callers fall
+// back to PID-only liveness.
+func procStartTime(pid int) uint64 {
+	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0
+	}
+	s := string(b)
+	i := strings.LastIndexByte(s, ')')
+	if i < 0 {
+		return 0
+	}
+	f := strings.Fields(s[i+1:])
+	if len(f) < 20 {
+		return 0
+	}
+	n, err := strconv.ParseUint(f[19], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func currentBootID() string {
+	b, err := os.ReadFile(bootIDPath)
+	if err != nil {
+		return "" // non-Linux or restricted /proc: degrade to PID-only liveness
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func (o interlockOwner) marshal() []byte {
+	return []byte(fmt.Sprintf("pid=%d\nboot=%s\nstart=%d\ntime=%s\n",
+		o.PID, o.BootID, o.Start, o.Written.UTC().Format(time.UnixDate)))
+}
+
+// parseInterlockOwner reports ok=false for any file it does not recognise —
+// including the empty file written by `touch` in an older install.sh and the
+// bare timestamp written by system-agent <= v0.3.16. Callers must keep the
+// legacy path for those.
+func parseInterlockOwner(contents []byte) (interlockOwner, bool) {
+	var o interlockOwner
+	var sawPID bool
+	s := bufio.NewScanner(strings.NewReader(string(contents)))
+	for s.Scan() {
+		k, v, found := strings.Cut(strings.TrimSpace(s.Text()), "=")
+		if !found {
+			continue
+		}
+		switch k {
+		case "pid":
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return interlockOwner{}, false
+			}
+			o.PID, sawPID = n, true
+		case "boot":
+			o.BootID = v
+		case "start":
+			if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+				o.Start = n
+			}
+		case "time":
+			if t, err := time.Parse(time.UnixDate, v); err == nil {
+				o.Written = t
+			}
+		}
+	}
+	return o, sawPID
+}
+
+// isAlive reports whether the writing process is still running. A boot ID that
+// differs from the current one means the file predates a reboot, so the PID —
+// which recycles across reboots — must not be trusted.
+func (o interlockOwner) isAlive() bool {
+	if cur := currentBootID(); cur != "" && o.BootID != "" && cur != o.BootID {
+		return false
+	}
+	if o.PID <= 0 {
+		return false
+	}
+	if o.PID == os.Getpid() {
+		return true
+	}
+	p, err := os.FindProcess(o.PID)
+	if err != nil {
+		return false
+	}
+	if p.Signal(syscall.Signal(0)) != nil {
+		return false
+	}
+	// PIDs recycle within a single boot. If we recorded the owner's start time,
+	// a mismatch means a different process is wearing the same PID.
+	if o.Start != 0 {
+		if cur := procStartTime(o.PID); cur != 0 && cur != o.Start {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/applyinator/interlock_test.go
+++ b/pkg/applyinator/interlock_test.go
@@ -1,0 +1,356 @@
+package applyinator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// spawnLiveProcess starts a child that stays alive for the duration of the test
+// and returns its PID. Using a real process rather than os.Getpid() exercises
+// the FindProcess/Signal path instead of the same-process short circuit.
+func spawnLiveProcess(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unable to start helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// spawnDeadPID starts a child, waits for it to exit, and returns its PID. The
+// PID is reaped, so it is genuinely gone rather than merely improbable.
+func spawnDeadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unable to start helper process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("helper process did not exit cleanly: %v", err)
+	}
+	return pid
+}
+
+func TestMarshalParseRoundtrip(t *testing.T) {
+	owner := newInterlockOwner(time.Now())
+	if owner.PID != os.Getpid() {
+		t.Fatalf("newInterlockOwner recorded pid %d, want %d", owner.PID, os.Getpid())
+	}
+
+	parsed, ok := parseInterlockOwner(owner.marshal())
+	if !ok {
+		t.Fatal("parseInterlockOwner returned ok=false for a freshly marshalled owner")
+	}
+	if parsed.PID != owner.PID {
+		t.Errorf("PID mismatch: got %d, want %d", parsed.PID, owner.PID)
+	}
+	if parsed.BootID != owner.BootID {
+		t.Errorf("BootID mismatch: got %q, want %q", parsed.BootID, owner.BootID)
+	}
+	if parsed.Start != owner.Start {
+		t.Errorf("Start mismatch: got %d, want %d", parsed.Start, owner.Start)
+	}
+	// UnixDate has second granularity, so compare truncated instants.
+	if want := owner.Written.Truncate(time.Second); !parsed.Written.Equal(want) {
+		t.Errorf("Written mismatch: got %v, want %v", parsed.Written.UTC(), want.UTC())
+	}
+}
+
+// TestMarshalWritesUTC guards the round-trip against local zone abbreviations.
+// time.Parse resolves an abbreviation it does not know to a zero offset, so
+// formatting in local time would decode to the wrong instant on most nodes.
+func TestMarshalWritesUTC(t *testing.T) {
+	// A zone with a non-UTC offset whose abbreviation Go cannot resolve on parse.
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	written := time.Date(2026, 7, 14, 9, 48, 43, 0, loc)
+	owner := interlockOwner{PID: 23056, BootID: "boot", Start: 99, Written: written}
+
+	raw := string(owner.marshal())
+	if !strings.Contains(raw, " UTC ") {
+		t.Errorf("marshalled timestamp is not in UTC: %q", raw)
+	}
+
+	parsed, ok := parseInterlockOwner([]byte(raw))
+	if !ok {
+		t.Fatal("parseInterlockOwner returned ok=false")
+	}
+	if !parsed.Written.Equal(written) {
+		t.Errorf("round-trip changed the instant: got %v, want %v", parsed.Written.UTC(), written.UTC())
+	}
+}
+
+func TestParseInterlockOwner(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		wantOK   bool
+		wantPID  int
+		wantBoot string
+		wantStrt uint64
+	}{
+		{
+			name:     "full record written by the agent",
+			contents: "pid=23056\nboot=abc-123\nstart=456\ntime=Mon Jul 14 09:48:43 UTC 2026\n",
+			wantOK:   true, wantPID: 23056, wantBoot: "abc-123", wantStrt: 456,
+		},
+		{
+			// install.sh writes no start= field; the agent must still accept it.
+			name:     "install.sh record without start",
+			contents: "pid=4242\nboot=abc-123\ntime=Mon Jul 14 09:48:43 UTC 2026\n",
+			wantOK:   true, wantPID: 4242, wantBoot: "abc-123", wantStrt: 0,
+		},
+		{
+			name:     "empty file from a legacy touch",
+			contents: "",
+			wantOK:   false,
+		},
+		{
+			name:     "bare timestamp from system-agent <= v0.3.16",
+			contents: "Mon Jul 14 09:48:43 CEST 2026",
+			wantOK:   false,
+		},
+		{
+			name:     "no pid key",
+			contents: "boot=abc-123\ntime=Mon Jul 14 09:48:43 UTC 2026\n",
+			wantOK:   false,
+		},
+		{
+			name:     "non-numeric pid",
+			contents: "pid=notanumber\nboot=abc-123\n",
+			wantOK:   false,
+		},
+		{
+			name:     "unknown keys are ignored",
+			contents: "pid=7\nfuture=value\nboot=b\n",
+			wantOK:   true, wantPID: 7, wantBoot: "b",
+		},
+		{
+			name:     "unparseable time leaves Written zero but still parses",
+			contents: "pid=7\nboot=b\ntime=not a date\n",
+			wantOK:   true, wantPID: 7, wantBoot: "b",
+		},
+		{
+			name:     "unparseable start is ignored",
+			contents: "pid=7\nstart=notanumber\n",
+			wantOK:   true, wantPID: 7, wantStrt: 0,
+		},
+		{
+			name:     "surrounding whitespace is tolerated",
+			contents: "  pid=7  \n\tboot=b\t\n",
+			wantOK:   true, wantPID: 7, wantBoot: "b",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseInterlockOwner([]byte(tc.contents))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.PID != tc.wantPID {
+				t.Errorf("PID = %d, want %d", got.PID, tc.wantPID)
+			}
+			if got.BootID != tc.wantBoot {
+				t.Errorf("BootID = %q, want %q", got.BootID, tc.wantBoot)
+			}
+			if got.Start != tc.wantStrt {
+				t.Errorf("Start = %d, want %d", got.Start, tc.wantStrt)
+			}
+		})
+	}
+}
+
+// TestParseUnparseableTimeLeavesWrittenZero pins the signal Apply relies on to
+// decide it must stamp its own observation time onto restart-pending.
+func TestParseUnparseableTimeLeavesWrittenZero(t *testing.T) {
+	got, ok := parseInterlockOwner([]byte("pid=7\nboot=b\ntime=not a date\n"))
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if !got.Written.IsZero() {
+		t.Errorf("Written = %v, want the zero time", got.Written)
+	}
+}
+
+func TestIsAliveSelf(t *testing.T) {
+	if !newInterlockOwner(time.Now()).isAlive() {
+		t.Error("current process should report as alive")
+	}
+}
+
+func TestIsAliveLiveChildProcess(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	owner := interlockOwner{PID: pid, BootID: currentBootID(), Start: procStartTime(pid)}
+	if !owner.isAlive() {
+		t.Errorf("live child pid %d should report as alive", pid)
+	}
+}
+
+func TestIsAliveDeadPID(t *testing.T) {
+	pid := spawnDeadPID(t)
+	owner := interlockOwner{PID: pid, BootID: currentBootID()}
+	if owner.isAlive() {
+		t.Errorf("reaped pid %d should not be reported as alive", pid)
+	}
+}
+
+func TestIsAliveOutOfRangePID(t *testing.T) {
+	// Above /proc/sys/kernel/pid_max on any realistic system.
+	owner := interlockOwner{PID: 99999999, BootID: currentBootID()}
+	if owner.isAlive() {
+		t.Error("non-existent PID should not be reported as alive")
+	}
+}
+
+// TestIsAliveRejectsNonPositivePID: os.Process.Signal happens to reject 0 and -1
+// on its own, so these cases are a guard against that changing.
+func TestIsAliveRejectsNonPositivePID(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		owner := interlockOwner{PID: pid, BootID: currentBootID()}
+		if owner.isAlive() {
+			t.Errorf("pid %d should not be reported as alive", pid)
+		}
+	}
+}
+
+// TestIsAliveRejectsNegativePIDOfLiveProcessGroup is the case the stdlib does
+// not cover: kill(-N, sig) addresses process *group* N, so a corrupt interlock
+// file holding a negative PID that happens to match a live process group would
+// be read as a live owner — wedging the agent permanently against a plan nobody
+// is applying.
+func TestIsAliveRejectsNegativePIDOfLiveProcessGroup(t *testing.T) {
+	cmd := exec.Command("sleep", "300")
+	// Put the child in its own process group, so its PGID equals its PID.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unable to start helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Skipf("unable to determine process group: %v", err)
+	}
+	if err := syscall.Kill(-pgid, 0); err != nil {
+		t.Skipf("process group %d is not signalable: %v", pgid, err)
+	}
+
+	owner := interlockOwner{PID: -pgid, BootID: currentBootID()}
+	if owner.isAlive() {
+		t.Errorf("pid %d addresses a live process group and must not be read as a live owner", -pgid)
+	}
+}
+
+func TestIsAliveBootIDMismatch(t *testing.T) {
+	if currentBootID() == "" {
+		t.Skip("boot id unavailable on this system")
+	}
+	pid := spawnLiveProcess(t)
+	owner := interlockOwner{PID: pid, BootID: "00000000-0000-0000-0000-000000000000"}
+	if owner.isAlive() {
+		t.Error("a file from a previous boot must be treated as stale even when the PID is live")
+	}
+}
+
+// TestIsAliveMissingBootIDDegradesToPID covers a file written where /proc was
+// unreadable, and the mixed-version case of an install.sh that wrote no boot id.
+func TestIsAliveMissingBootIDDegradesToPID(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	if !(interlockOwner{PID: pid, BootID: ""}).isAlive() {
+		t.Error("empty boot id should fall back to PID-only liveness, not fail closed")
+	}
+	dead := spawnDeadPID(t)
+	if (interlockOwner{PID: dead, BootID: ""}).isAlive() {
+		t.Error("empty boot id with a dead PID should still report dead")
+	}
+}
+
+// TestIsAliveStartTimeMismatch is the PID-reuse guard: a different process
+// wearing a recycled PID within the same boot must not be mistaken for the
+// interlock's owner.
+func TestIsAliveStartTimeMismatch(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	actual := procStartTime(pid)
+	if actual == 0 {
+		t.Skip("/proc start time unavailable on this system")
+	}
+	owner := interlockOwner{PID: pid, BootID: currentBootID(), Start: actual + 1}
+	if owner.isAlive() {
+		t.Error("start time mismatch should be treated as a recycled PID, not a live owner")
+	}
+}
+
+func TestIsAliveStartTimeZeroSkipsCheck(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	owner := interlockOwner{PID: pid, BootID: currentBootID(), Start: 0}
+	if !owner.isAlive() {
+		t.Error("a missing start time must degrade to PID-only liveness, not fail closed")
+	}
+}
+
+func TestProcStartTime(t *testing.T) {
+	self := procStartTime(os.Getpid())
+	if self == 0 {
+		t.Skip("/proc start time unavailable on this system")
+	}
+	if again := procStartTime(os.Getpid()); again != self {
+		t.Errorf("start time is not stable: %d then %d", self, again)
+	}
+	if got := procStartTime(99999999); got != 0 {
+		t.Errorf("start time for a non-existent pid = %d, want 0", got)
+	}
+	// A distinct process started later must have a different start time,
+	// otherwise the PID-reuse guard has no discriminating power.
+	child := spawnLiveProcess(t)
+	if got := procStartTime(child); got == 0 {
+		t.Errorf("start time for live child pid %d = 0", child)
+	}
+}
+
+// TestProcStartTimeCommWithSpaces covers the parsing hazard in /proc/<pid>/stat:
+// field 2 is the executable name in parentheses and may itself contain spaces
+// and ')', so fields must be counted from the last ')' rather than split naively.
+func TestProcStartTimeCommWithSpaces(t *testing.T) {
+	// Field 22 (index 19 after the final ')') is 4242.
+	fields := make([]string, 0, 30)
+	for i := 3; i <= 30; i++ {
+		if i == 22 {
+			fields = append(fields, "4242")
+			continue
+		}
+		fields = append(fields, fmt.Sprintf("%d", i))
+	}
+	stat := "1234 (weird ) name) S " + strings.Join(fields[1:], " ")
+
+	// Exercise the same slicing procStartTime performs.
+	i := strings.LastIndexByte(stat, ')')
+	if i < 0 {
+		t.Fatal("test fixture has no ')'")
+	}
+	f := strings.Fields(stat[i+1:])
+	if len(f) < 20 {
+		t.Fatalf("fixture produced only %d fields", len(f))
+	}
+	if f[19] != "4242" {
+		t.Errorf("field 22 = %q, want %q — comm containing ')' broke field counting", f[19], "4242")
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/system-agent/issues/403

## Problem

The agent creates `interlock/applyinator-active` before reconciling a plan and removes it in a `defer` afterwards. If it is killed in between — an OOM kill, or a `SIGKILL` while blocked on a stalled disk — the file is left behind, and **nothing ever cleared it**.

Two separate defects put it in that state and kept it there.

**1. The self-heal checks the wrong path.** `pkg/applyinator/applyinator.go:111-112` stats and removes `applyinatorActiveInterlockFile` — the bare constant `"applyinator-active"` — rather than `applyinatorActiveInterlockFilePath`, the joined path computed on the line directly above:

```go
applyinatorActiveInterlockFilePath := filepath.Join(a.interlockDir, applyinatorActiveInterlockFile)
// First off, remove check and remove the active interlock as the applyinator is not actually active
if _, err := os.Stat(applyinatorActiveInterlockFile); err == nil {      // <-- bare filename
    err = os.Remove(applyinatorActiveInterlockFile)                     // <-- bare filename
    if err != nil {
        logrus.Errorf("unable to remove applyinator active interlock file %s: %v",
            applyinatorActiveInterlockFilePath, err)                    // <-- correct variable
    }
}
```

The generated systemd unit sets no `WorkingDirectory=`, so systemd supplies `/`. The path actually stated is `/applyinator-active`, which never exists. The `logrus.Errorf` on the next line already uses the right variable, so the intent is unambiguous — this block was meant to be the self-heal, and it has never run.

**2. Existence was treated as evidence.** `install.sh`'s `ensure_applyinator_not_active` took the file's mere presence to mean "a plan is being applied" and slept 5 seconds × 60. A leaked file therefore cost **five minutes on every subsequent installer run**, indefinitely, for a plan that was not running.

The root cause of both is the same: the file records *that* an apply started, but nothing about *who* started it. There is no way to distinguish a live holder from a dead one, so the code either has to trust it (and stall) or ignore it (and risk two agents applying plans concurrently).

## Solution

Stamp the file with the identity of the process that wrote it, and check whether that process is still alive.

```
pid=1234
boot=4c9c7f2e-3b1a-4f7c-9d2e-8a6b5c4d3e2f
start=98217
time=Mon Aug 24 09:14:02 UTC 2026
```

New file `pkg/applyinator/interlock.go` owns the format: `newInterlockOwner`, `marshal`, `parseInterlockOwner`, `isAlive`.

Liveness is `kill(pid, 0)`, narrowed by two guards that each close a real false-positive:

| Field | Catches | If unavailable |
|---|---|---|
| `boot=` (`/proc/sys/kernel/random/boot_id`) | A PID that is live **after a reboot** but belongs to something else entirely | Degrades to PID-only liveness |
| `start=` (field 22 of `/proc/<pid>/stat`) | A PID **recycled within a single boot**, which the boot id cannot see | Degrades to PID-only liveness |

Both degrade rather than failing closed: on a non-Linux or restricted `/proc`, the check gets weaker, not wrong.

Non-positive PIDs are rejected **before** signalling. `kill(0, sig)` addresses the caller's entire process group and `kill(-1, sig)` every process it may signal, so a corrupt `pid=0` or `pid=-1` would otherwise report as alive.

`start=` is parsed from after the **last** `)` in `/proc/<pid>/stat`, because `comm` is unquoted and may itself contain spaces and parentheses.

The timestamp is written and parsed **in UTC**. `time.UnixDate` carries a zone abbreviation, and `time.Parse` resolves an abbreviation it does not know to a **zero offset** rather than failing — so a record written in local time would silently round-trip to the wrong instant on most nodes. (`CEST` parses to +0000; a numeric `+0530` does not parse at all.)

With that in place:

- **`Apply` refuses** rather than trampling a live holder's interlock, and clears the file otherwise. Deleting another agent's interlock would mean two agents applying plans concurrently, so the check must be conservative in that direction.
- **`install.sh` reads `pid=`** and short-circuits its wait when that process is gone. Five minutes becomes immediate.
- **`ExecStartPre=-/bin/rm -f …/interlock/applyinator-active`** clears the file before the agent starts. This is the backstop for the one case liveness cannot resolve: a PID recycled *across* an agent restart, where the check would correctly report "alive" about the wrong process. The leading `-` keeps a missing `/bin/rm` from failing the unit.


### Backward compatibility

Neither legacy format parses as an owner record, and both keep their previous handling:

| Written by | Contents | Handling |
|---|---|---|
| `install.sh` before this PR | empty (bare `touch`) | Unchanged — installer waits out the timeout, agent clears the file |
| system-agent ≤ v0.3.16 | bare `time.UnixDate` timestamp | Unchanged — as above |
| Anything else | junk | Treated as legacy |

A new installer against an old binary and an old installer against a new binary both stay correct: the worst case is the pre-PR behaviour.

#### Manual Testing

All of these run on a throwaway VM or privileged container. **No Rancher server and no Kubernetes cluster is needed** — the agent's local plan mode exercises the same `Apply` path.

<details>
<summary><strong>Harness setup</strong> (shared by PRs A, B and C)</summary>

```sh
# As root, on a throwaway machine.
git clone https://github.com/marytlf/system-agent && cd system-agent
git checkout fix-a-owner-stamped-interlock
CGO_ENABLED=0 go build -o /usr/local/bin/rancher-system-agent .

mkdir -p /var/lib/rancher/agent/{work,plans,applied,interlock} /etc/rancher/agent

cat > /etc/rancher/agent/config.yaml <<'EOF'
workDirectory: /var/lib/rancher/agent/work
localEnabled: true
localPlanDirectory: /var/lib/rancher/agent/plans
appliedPlanDirectory: /var/lib/rancher/agent/applied
interlockDirectory: /var/lib/rancher/agent/interlock
remoteEnabled: false
preserveWorkDirectory: true
EOF
chown root:root /etc/rancher/agent/config.yaml
chmod 0600 /etc/rancher/agent/config.yaml     # the agent rejects any other mode

# A plan that runs long enough to catch the agent mid-apply.
cat > /var/lib/rancher/agent/plans/test.plan <<'EOF'
{
  "instructions": [
    {
      "name": "install-rke2",
      "image": "docker.io/rancher/system-agent-installer-rke2:v1.20.6-rke2r1",
      "command": "/bin/sh",
      "args": [
        "-c",
        "echo hello from the plan; sleep 60"
      ]
    }
  ]
}
EOF

run_agent() { CATTLE_LOGLEVEL=debug /usr/local/bin/rancher-system-agent sentinel; }
```

The local watcher polls every 5s. A plan is applied once; delete `/var/lib/rancher/agent/plans/test.pos` to make it apply again.
</details>

**A1 — The wrong-path bug, reproduced and fixed.** This is the headline defect.

```sh
# On main, first, to see the bug:
git checkout main && CGO_ENABLED=0 go build -o /usr/local/bin/rancher-system-agent .
printf 'x' > /var/lib/rancher/agent/interlock/applyinator-active
run_agent   # let one apply happen, then Ctrl-C
ls -l /var/lib/rancher/agent/interlock/applyinator-active   # STILL THERE — never cleared

# On this branch:
git checkout fix-a-owner-stamped-interlock && CGO_ENABLED=0 go build -o /usr/local/bin/rancher-system-agent .
printf 'x' > /var/lib/rancher/agent/interlock/applyinator-active
rm -f /var/lib/rancher/agent/plans/test.pos
run_agent   # Ctrl-C after the apply
```

Expect: `removing stale active interlock file …` in the log, and the file gone.

**A2 — Leaked file from a dead agent is cleared, not waited on.** This is the five-minute stall.

```sh
# Simulate a leaked interlock owned by a PID that no longer exists.
sh -c 'echo $$' > /tmp/deadpid
printf 'pid=%s\nboot=%s\ntime=%s\n' "$(cat /tmp/deadpid)" \
  "$(cat /proc/sys/kernel/random/boot_id)" "$(LC_ALL=C date -u '+%a %b %e %H:%M:%S UTC %Y')" \
  > /var/lib/rancher/agent/interlock/applyinator-active

# Load install.sh's helpers WITHOUT running the installer. Sourcing it directly
# would execute do_install; the sed strips everything from do_install onward.
load_installsh_helpers() { eval "$(sed '/^do_install/,$d' ./install.sh)"; }

time sh -c 'eval "$(sed "/^do_install/,\$d" ./install.sh)"
            CATTLE_AGENT_VAR_DIR=/var/lib/rancher/agent ensure_applyinator_not_active'
```

Expect: returns in **under a second** with `Active plan interlock owned by pid N, which is no longer running`. On `main` this takes 5 minutes.

**A3 — A genuinely live holder is still respected.** The counterweight — a false negative here means two agents applying plans at once.

```sh
sleep 600 & LIVE=$!
printf 'pid=%s\nboot=%s\ntime=%s\n' "$LIVE" "$(cat /proc/sys/kernel/random/boot_id)" \
  "$(LC_ALL=C date -u '+%a %b %e %H:%M:%S UTC %Y')" \
  > /var/lib/rancher/agent/interlock/applyinator-active
rm -f /var/lib/rancher/agent/plans/test.pos
run_agent
```

Expect: `another system-agent process (pid N) is applying a plan; refusing to apply concurrently`, and the file **still present**. Then `kill $LIVE` and confirm the next poll (5s) proceeds and clears it.

**A4 — Across a reboot.** A PID can be live after a reboot and belong to something else.

```sh
printf 'pid=1\nboot=00000000-0000-0000-0000-000000000000\ntime=%s\n' \
  "$(LC_ALL=C date -u '+%a %b %e %H:%M:%S UTC %Y')" \
  > /var/lib/rancher/agent/interlock/applyinator-active
rm -f /var/lib/rancher/agent/plans/test.pos && run_agent
```

PID 1 is unambiguously alive, so this passes only if the boot-id guard works. Expect the file cleared and the plan applied.

**A5 — The real scenario, end to end.** Closest to the ticket.

```sh
rm -f /var/lib/rancher/agent/plans/test.pos
run_agent &                                  # let the 60s sleep instruction start
sleep 10
cat /var/lib/rancher/agent/interlock/applyinator-active   # owner-stamped, pid = the agent
kill -9 %1                                   # SIGKILL: no defer, no drain
ls -l /var/lib/rancher/agent/interlock/      # leaked, as expected

rm -f /var/lib/rancher/agent/plans/test.pos
run_agent                                    # restart
```

Expect: the new agent clears the leaked file and applies the plan. On `main` the file survives and every `install.sh` run afterwards costs five minutes.

**A6 — `ExecStartPre` backstop.** On a node with the agent installed from this branch's `install.sh`:

```sh
systemctl cat rancher-system-agent | grep ExecStartPre
touch /var/lib/rancher/agent/interlock/applyinator-active
systemctl restart rancher-system-agent
ls -l /var/lib/rancher/agent/interlock/      # gone
```

**A7 — Legacy compatibility.** An empty file (old `install.sh`) carries no PID, so the installer cannot test liveness and must fall back to waiting rather than deleting a possibly-live holder's interlock:

```sh
: > /var/lib/rancher/agent/interlock/applyinator-active
sh -c 'eval "$(sed "/^do_install/,\$d" ./install.sh)"
       CATTLE_AGENT_VAR_DIR=/var/lib/rancher/agent
       APPLYINATOR_ACTIVE_WAIT_COUNT=2
       ensure_applyinator_not_active'   # waits out the timeout, then removes
```

#### Automated Testing

`pkg/applyinator/interlock_test.go` — 16 tests on the format and liveness check: marshal/parse round-trip, a 10-case parse table (both legacy formats, missing `pid`, non-numeric `pid`, unknown keys, unparseable `time`/`start`, whitespace), self/live-child/dead/out-of-range PIDs, non-positive PIDs, a **negative PID naming a live process group**, boot-id mismatch, missing boot id, start-time mismatch, `start=0`, and `/proc` parsing including a `comm` containing spaces and parens.

`pkg/applyinator/apply_interlock_test.go` — 7 tests driving `Apply` end to end: stale owner cleared, live owner refused, cleared after a reboot, cleared on PID reuse, all three legacy formats, its own interlock cleared on the happy path, and (root-gated) the file's contents captured *while a plan is running* by an instruction that `cat`s it.

`pkg/applyinator/installsh_test.go` — 5 cross-language contract tests that `eval` `install.sh`'s helpers and assert on real behaviour: a dead owner returns in <3s, no file returns immediately, a live owner is waited on, a legacy file falls back to the timeout, and the `ExecStartPre` line is present with its `-` prefix.

Unprivileged runners cannot `chown` to root, which executing an instruction requires, so the tests use the presence of a `<datecode>-applied.plan` file in `appliedPlanDirectory` as the "`Apply` got past the interlock gate" signal. One test genuinely needs instruction execution and skips unless run as root.

**Mutation testing.** Reverting each fix individually fails the intended test:

| Mutation | Caught by |
|---|---|
| Restore the bare-filename `os.Stat` (the original bug) | `TestApplyRefusesWhenActiveInterlockOwnerAlive` |
| Drop the boot-ID check | `TestApplyRemovesActiveInterlockAfterReboot`, `TestIsAliveBootIDMismatch` |
| Drop the `PID <= 0` guard | `TestIsAliveRejectsNegativePIDOfLiveProcessGroup` |
| Drop the start-time / PID-reuse check | `TestApplyRemovesActiveInterlockOnPIDReuse`, `TestIsAliveStartTimeMismatch` |

The `PID <= 0` case is worth a note: an obvious test using `pid=0` does **not** catch its removal, because Go's `os.Process.Signal` already rejects 0 and -1 before reaching the kernel. Only a negative PID naming a real process group gets far enough to expose it.

### QA Testing Considerations

- The scenario is **agent killed mid-apply**, so the relevant signals are `SIGKILL` and OOM, not a clean `systemctl stop`.
- Worth covering on a node that **reboots** between the leak and the recovery — that is the path the boot id exists for.
- Upgrade path matters both ways: old agent → new `install.sh`, and new agent → old `install.sh`. Both should behave no worse than today.
- A **non-Linux** or hardened node with a restricted `/proc` should degrade to PID-only liveness, not error.
- The five-minute `ensure_applyinator_not_active` stall is the most visible symptom; it is the clearest thing to measure before and after.

### Regressions Considerations

- **Two agents applying concurrently.** `Apply` now returns an error where it previously deleted the file and continued. Intended, but a false *positive* on the liveness check would block a legitimate apply. The boot id and start time exist to make false positives unlikely; `ExecStartPre` covers the remaining window.
- **Interlock file format.** `install.sh` and the agent write and parse this format in two languages with no shared definition. `installsh_test.go` pins it. If it drifts, `parseInterlockOwner` returns `ok=false` and the code silently falls back to the legacy path with **no error logged** — a quiet regression, hence the contract test.
- **Timezone.** A node in a half-hour zone (`+0530`) or one whose abbreviation Go does not know (`CEST`) would previously have skewed a timestamp comparison. Both sides now write UTC. Worth a spot check on a node with a non-UTC `TZ`.
- **`/proc` availability.** Containerised or hardened environments may hide `/proc/<pid>/stat`. Handled as "unknown", but worth confirming on any locked-down image in the support matrix.
