### PR TITLE
Clear the active interlock on graceful shutdown

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -929,6 +929,24 @@ ensure_applyinator_not_active() {
     rm -f "${FILE_APPLYINATOR}"
 }
 
+write_interlock_owner() {
+    _boot=""
+    if [ -r /proc/sys/kernel/random/boot_id ]; then
+        _boot=$(cat /proc/sys/kernel/random/boot_id)
+    fi
+    # Format must match interlockOwner.marshal() in pkg/applyinator/interlock.go.
+    # LC_ALL=C keeps the day/month names parseable by Go's time.UnixDate, and the
+    # timestamp is written in UTC with a literal "UTC" zone: Go's UnixDate layout
+    # cannot parse a numeric zone (glibc %Z emits e.g. "+0530" where the zone has
+    # no abbreviation), and it resolves an unknown abbreviation like "CEST" to a
+    # zero offset, which would skew the timeout window.
+    # No start= field is written here: the agent treats a missing one as "unknown"
+    # and falls back to PID-only liveness, which is sufficient for the short,
+    # trap-guarded window the installer holds this file.
+    printf 'pid=%s\nboot=%s\ntime=%s\n' "$$" "${_boot}" "$(LC_ALL=C date -u '+%a %b %e %H:%M:%S UTC %Y')" > "$1"
+    chmod 0600 "$1"
+}
+
 do_install() {
     if [ $(id -u) != 0 ]; then
       fatal "This script must be run as root."
@@ -940,7 +958,11 @@ do_install() {
     ensure_directories
     verify_downloader curl || fatal "can not find curl for downloading files"
 
-    touch ${CATTLE_AGENT_VAR_DIR}/interlock/restart-pending
+    # Stamp the file with this shell's identity so the agent can tell a live
+    # installer from one that was killed, and remove it on any exit path — every
+    # fatal between here and the final rm previously leaked it.
+    write_interlock_owner ${CATTLE_AGENT_VAR_DIR}/interlock/restart-pending
+    trap 'rm -f ${CATTLE_AGENT_VAR_DIR}/interlock/restart-pending' EXIT INT TERM
     ensure_applyinator_not_active
 
     if [ -z "${CATTLE_CA_CHECKSUM}" ] && [ $(echo "${CATTLE_AGENT_STRICT_VERIFY}" | tr '[:upper:]' '[:lower:]') = "true" ]; then

--- a/install.sh
+++ b/install.sh
@@ -592,6 +592,7 @@ RestartSec=5s
 Environment=CATTLE_LOGLEVEL=${CATTLE_AGENT_LOGLEVEL}
 Environment=CATTLE_AGENT_CONFIG=${CATTLE_AGENT_CONFIG_DIR}/config.yaml
 Environment=CATTLE_AGENT_STRICT_VERIFY=${CATTLE_AGENT_STRICT_VERIFY}
+ExecStartPre=-/bin/rm -f ${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active
 ExecStart=${CATTLE_AGENT_BIN_PREFIX}/bin/rancher-system-agent sentinel
 EOF
 
@@ -908,16 +909,24 @@ create_env_file() {
 }
 
 ensure_applyinator_not_active() {
+    FILE_APPLYINATOR="${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active"
     i=1
     while [ "${i}" -ne "${APPLYINATOR_ACTIVE_WAIT_COUNT}" ]; do
-      if [ -f "${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active" ]; then
+        [ -f "${FILE_APPLYINATOR}" ] || return 0
+        # The agent stamps this file with its pid. If that process is gone the file
+        # is a leftover, so there is nothing to wait for.
+        _pid=$(sed -n 's/^pid=//p' "${FILE_APPLYINATOR}" 2>/dev/null | head -1)
+        if [ -n "${_pid}" ] && ! kill -0 "${_pid}" 2>/dev/null; then
+            info "Active plan interlock owned by pid ${_pid}, which is no longer running. Removing stale interlock file."
+            rm -f "${FILE_APPLYINATOR}"
+            return 0
+        fi
         i=$((i + 1))
         info "Active plan reconciliation detected. Sleeping for 5 seconds and retrying check"
         sleep 5
-        continue
-      fi
-      break
     done
+    warn "Ignoring active plan interlock ${FILE_APPLYINATOR} after timeout; removing it."
+    rm -f "${FILE_APPLYINATOR}"
 }
 
 do_install() {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/mattn/go-colorable"
 	"github.com/sirupsen/logrus"
@@ -23,6 +25,10 @@ const (
 	cattleAgentConfigEnv       = "CATTLE_AGENT_CONFIG"
 	cattleAgentStrictVerifyEnv = "CATTLE_AGENT_STRICT_VERIFY"
 	defaultConfigFile          = "/etc/rancher/agent/config.yaml"
+
+	// applyDrainTimeout bounds how long shutdown waits for an in-flight apply.
+	// wrangler hard-exits on a second signal, so this cannot be open-ended.
+	applyDrainTimeout = 30 * time.Second
 )
 
 func main() {
@@ -125,6 +131,13 @@ func run(_ *cli.Context) error {
 	}
 
 	<-topContext.Done()
+
+	// Give an in-flight Apply a bounded window to finish and clear its interlock
+	// before exiting. topContext is already cancelled here, so the drain needs a
+	// context of its own.
+	drainCtx, cancel := context.WithTimeout(context.Background(), applyDrainTimeout)
+	defer cancel()
+	applyinator.Drain(drainCtx)
 	return nil
 }
 

--- a/pkg/applyinator/apply_interlock_test.go
+++ b/pkg/applyinator/apply_interlock_test.go
@@ -1,0 +1,257 @@
+package applyinator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	planapi "github.com/rancher/rancher/pkg/plan"
+)
+
+// testEnv bundles an Applyinator with the paths the interlock tests assert on.
+type testEnv struct {
+	a *Applyinator
+	// active and restartPending are the two interlock files.
+	active         string
+	restartPending string
+	// appliedPlanDir receives a "<datecode>-applied.plan" file once Apply gets
+	// past the interlock gate. Unlike executing an instruction, writing it does
+	// not require root, so it is the signal these tests use for "Apply
+	// proceeded".
+	appliedPlanDir string
+}
+
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	interlockDir := t.TempDir()
+	appliedPlanDir := t.TempDir()
+	return &testEnv{
+		a:              NewApplyinator(t.TempDir(), false, appliedPlanDir, interlockDir, nil),
+		active:         filepath.Join(interlockDir, applyinatorActiveInterlockFile),
+		restartPending: filepath.Join(interlockDir, restartPendingInterlockFile),
+		appliedPlanDir: appliedPlanDir,
+	}
+}
+
+// apply runs a minimal plan. One-time instructions are deliberately not run:
+// executing one chowns the working directory to root, which unprivileged test
+// runners cannot do, and the interlock gate gets no say in what runs afterwards.
+func (e *testEnv) apply(t *testing.T) (ApplyOutput, error) {
+	t.Helper()
+	return e.a.Apply(context.Background(), ApplyInput{
+		CalculatedPlan: CalculatedPlan{Checksum: "testchecksum"},
+	})
+}
+
+func (e *testEnv) planWasApplied(t *testing.T) bool {
+	t.Helper()
+	entries, err := os.ReadDir(e.appliedPlanDir)
+	if err != nil {
+		t.Fatalf("unable to read applied plan dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), appliedPlanFileSuffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// assertProceeded asserts Apply got past the interlock gate.
+func (e *testEnv) assertProceeded(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Apply returned an unexpected error: %v", err)
+	}
+	if !e.planWasApplied(t) {
+		t.Error("Apply returned nil but never reached the apply stage")
+	}
+}
+
+// assertBlocked asserts Apply refused, with an error mentioning want, and never
+// reached the apply stage.
+func (e *testEnv) assertBlocked(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("Apply returned nil error, want it to be blocked by an interlock")
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %v, want it to contain %q", err, want)
+	}
+	if e.planWasApplied(t) {
+		t.Error("Apply reached the apply stage despite being blocked")
+	}
+}
+
+func writeOwner(t *testing.T, path string, o interlockOwner) {
+	t.Helper()
+	if err := os.WriteFile(path, o.marshal(), 0600); err != nil {
+		t.Fatalf("unable to write interlock file %s: %v", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path, what string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("%s: expected %s to be gone, stat err = %v", what, path, err)
+	}
+}
+
+func mustExist(t *testing.T, path, what string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("%s: expected %s to still exist, stat err = %v", what, path, err)
+	}
+}
+
+func liveOwner(t *testing.T) interlockOwner {
+	t.Helper()
+	pid := spawnLiveProcess(t)
+	return interlockOwner{PID: pid, BootID: currentBootID(), Start: procStartTime(pid), Written: time.Now()}
+}
+
+func deadOwner(t *testing.T) interlockOwner {
+	t.Helper()
+	return interlockOwner{PID: spawnDeadPID(t), BootID: currentBootID(), Written: time.Now()}
+}
+
+// TestApplyRemovesStaleActiveInterlock is the direct regression test for the
+// wrong-path stat: before the fix Apply looked for a bare "applyinator-active"
+// relative to the working directory (systemd supplies "/"), so a leaked file was
+// never cleared and every subsequent install.sh burned five minutes on it.
+func TestApplyRemovesStaleActiveInterlock(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.active, deadOwner(t))
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "stale interlock from a dead owner")
+}
+
+// TestApplyRefusesWhenActiveInterlockOwnerAlive is the counterweight: the new
+// liveness check must not become a licence to trample a genuinely concurrent
+// apply. A false negative here means two agents applying plans at once.
+func TestApplyRefusesWhenActiveInterlockOwnerAlive(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.active, liveOwner(t))
+
+	_, err := e.apply(t)
+	e.assertBlocked(t, err, "refusing to apply concurrently")
+	mustExist(t, e.active, "live holder's interlock must not be deleted")
+}
+
+// TestApplyRemovesActiveInterlockAfterReboot: a PID may well be live after a
+// reboot, belonging to something else entirely.
+func TestApplyRemovesActiveInterlockAfterReboot(t *testing.T) {
+	if currentBootID() == "" {
+		t.Skip("boot id unavailable on this system")
+	}
+	e := newTestEnv(t)
+	owner := liveOwner(t)
+	owner.BootID = "00000000-0000-0000-0000-000000000000"
+	writeOwner(t, e.active, owner)
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "interlock from a previous boot")
+}
+
+// TestApplyRemovesActiveInterlockOnPIDReuse covers a recycled PID within a single
+// boot, which the boot id cannot catch.
+func TestApplyRemovesActiveInterlockOnPIDReuse(t *testing.T) {
+	e := newTestEnv(t)
+	owner := liveOwner(t)
+	if owner.Start == 0 {
+		t.Skip("/proc start time unavailable on this system")
+	}
+	owner.Start++ // a different process wearing this PID
+	writeOwner(t, e.active, owner)
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "interlock whose owner's start time does not match")
+}
+
+// TestApplyRemovesLegacyActiveInterlock covers a new binary meeting a file
+// written by an older install.sh (bare touch) or an older agent (bare timestamp).
+func TestApplyRemovesLegacyActiveInterlock(t *testing.T) {
+	for _, tc := range []struct{ name, contents string }{
+		{"empty file from a legacy touch", ""},
+		{"bare timestamp from an older agent", time.Now().Format(time.UnixDate)},
+		{"unrecognised junk", "garbage\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestEnv(t)
+			if err := os.WriteFile(e.active, []byte(tc.contents), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := e.apply(t)
+			e.assertProceeded(t, err)
+			mustNotExist(t, e.active, "legacy interlock")
+		})
+	}
+}
+
+// TestApplyClearsItsOwnInterlock: the deferred cleanup on the happy path.
+func TestApplyClearsItsOwnInterlock(t *testing.T) {
+	e := newTestEnv(t)
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.active, "interlock after a completed apply")
+}
+
+// TestApplyWritesOwnerStampedInterlockWhileRunning proves the file exists while
+// the plan is running and carries this process's identity. It needs a plan that
+// actually executes, and executing an instruction chowns the working directory
+// to root.
+func TestApplyWritesOwnerStampedInterlockWhileRunning(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("executing an instruction chowns the working directory to root; run as root to cover this")
+	}
+	e := newTestEnv(t)
+	captured := filepath.Join(t.TempDir(), "captured")
+
+	out, err := e.a.Apply(context.Background(), ApplyInput{
+		CalculatedPlan: CalculatedPlan{
+			Checksum: "testchecksum",
+			Plan: planapi.Plan{
+				OneTimeInstructions: []planapi.OneTimeInstruction{{
+					CommonInstruction: planapi.CommonInstruction{
+						Name:    "capture",
+						Command: "/bin/sh",
+						Args:    []string{"-c", "cat " + e.active + " > " + captured},
+					},
+				}},
+			},
+		},
+		RunOneTimeInstructions: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply returned an unexpected error: %v", err)
+	}
+	if !out.OneTimeApplySucceeded {
+		t.Fatal("plan did not run, so the interlock was never captured")
+	}
+
+	contents, err := os.ReadFile(captured)
+	if err != nil {
+		t.Fatalf("interlock file did not exist while the plan was running: %v", err)
+	}
+	owner, ok := parseInterlockOwner(contents)
+	if !ok {
+		t.Fatalf("interlock written during apply is not owner-stamped: %q", contents)
+	}
+	if owner.PID != os.Getpid() {
+		t.Errorf("interlock pid = %d, want this process %d", owner.PID, os.Getpid())
+	}
+	if owner.BootID != currentBootID() {
+		t.Errorf("interlock boot id = %q, want %q", owner.BootID, currentBootID())
+	}
+	if want := procStartTime(os.Getpid()); want != 0 && owner.Start != want {
+		t.Errorf("interlock start = %d, want %d", owner.Start, want)
+	}
+	mustNotExist(t, e.active, "interlock after a completed apply")
+}

--- a/pkg/applyinator/apply_restart_pending_test.go
+++ b/pkg/applyinator/apply_restart_pending_test.go
@@ -1,0 +1,142 @@
+package applyinator
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestApplyClearsRestartPendingFromDeadInstaller: install.sh writes this file and
+// removes it on the happy path. If it is killed in between, the agent previously
+// served the full five-minute timeout — and restarted that clock on every agent
+// restart, so it never expired.
+func TestApplyClearsRestartPendingFromDeadInstaller(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.restartPending, deadOwner(t))
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.restartPending, "restart-pending from a dead installer")
+}
+
+// TestApplyHonoursRestartPendingFromLiveInstaller: the interlock exists to stop
+// the agent applying a plan against a binary that is mid-replacement.
+func TestApplyHonoursRestartPendingFromLiveInstaller(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.restartPending, liveOwner(t))
+
+	_, err := e.apply(t)
+	e.assertBlocked(t, err, "restart is pending")
+	mustExist(t, e.restartPending, "live installer's restart-pending must not be deleted")
+}
+
+// TestApplyForcesThroughExpiredRestartPending keeps the existing safety valve:
+// even a live installer cannot block applies forever.
+func TestApplyForcesThroughExpiredRestartPending(t *testing.T) {
+	e := newTestEnv(t)
+	owner := liveOwner(t)
+	owner.Written = time.Now().Add(-2 * restartPendingTimeout)
+	writeOwner(t, e.restartPending, owner)
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.restartPending, "expired restart-pending")
+}
+
+// TestApplyStampsRestartPendingWithoutTimestamp: an owner-stamped file whose
+// time= is missing or unparseable has no defined window start. The agent must
+// stamp its own observation time and block — not force through, which would
+// defeat the interlock while the installer is still live.
+func TestApplyStampsRestartPendingWithoutTimestamp(t *testing.T) {
+	e := newTestEnv(t)
+	pid := spawnLiveProcess(t)
+	record := "pid=" + strconv.Itoa(pid) + "\nboot=" + currentBootID() + "\ntime=not a date\n"
+	if err := os.WriteFile(e.restartPending, []byte(record), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := e.apply(t)
+	e.assertBlocked(t, err, "restart is pending")
+	mustExist(t, e.restartPending, "restart-pending must be kept and stamped")
+
+	contents, err := os.ReadFile(e.restartPending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, ok := parseInterlockOwner(contents)
+	if !ok {
+		t.Fatalf("stamped file no longer parses: %q", contents)
+	}
+	if owner.Written.IsZero() {
+		t.Error("Written is still zero: the observation time was not stamped")
+	}
+	if owner.PID != pid {
+		t.Errorf("stamping clobbered the owner: pid = %d, want %d", owner.PID, pid)
+	}
+
+	// The stamped window must be honoured on the next pass, not restarted.
+	e2 := &testEnv{a: e.a, active: e.active, restartPending: e.restartPending, appliedPlanDir: e.appliedPlanDir}
+	_, err = e2.apply(t)
+	e2.assertBlocked(t, err, "restart is pending")
+}
+
+// TestApplyLegacyRestartPending covers an old install.sh against a new binary:
+// the bare `touch` and bare-timestamp behaviour must be unchanged.
+func TestApplyLegacyRestartPending(t *testing.T) {
+	t.Run("empty file blocks and is stamped with the observation time", func(t *testing.T) {
+		e := newTestEnv(t)
+		if err := os.WriteFile(e.restartPending, nil, 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := e.apply(t)
+		e.assertBlocked(t, err, "restart is pending")
+
+		contents, err := os.ReadFile(e.restartPending)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, parseErr := time.Parse(time.UnixDate, string(contents)); parseErr != nil {
+			t.Errorf("legacy file was not stamped with a parseable time: %q", contents)
+		}
+	})
+
+	t.Run("recent bare timestamp blocks", func(t *testing.T) {
+		e := newTestEnv(t)
+		if err := os.WriteFile(e.restartPending, []byte(time.Now().Format(time.UnixDate)), 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := e.apply(t)
+		e.assertBlocked(t, err, "restart is pending")
+		mustExist(t, e.restartPending, "recent legacy restart-pending")
+	})
+
+	t.Run("expired bare timestamp is cleared", func(t *testing.T) {
+		e := newTestEnv(t)
+		stamp := time.Now().Add(-2 * restartPendingTimeout).Format(time.UnixDate)
+		if err := os.WriteFile(e.restartPending, []byte(stamp), 0600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := e.apply(t)
+		e.assertProceeded(t, err)
+		mustNotExist(t, e.restartPending, "expired legacy restart-pending")
+	})
+}
+
+// TestApplyAcceptsInstallShFormat pins the cross-language contract: the exact
+// three-line record install.sh's write_interlock_owner emits, with no start=
+// field, must be understood by the agent. If the two drift, the restart-pending
+// fix silently reverts to the legacy five-minute path.
+func TestApplyAcceptsInstallShFormat(t *testing.T) {
+	e := newTestEnv(t)
+	record := "pid=" + strconv.Itoa(spawnDeadPID(t)) +
+		"\nboot=" + currentBootID() +
+		"\ntime=" + time.Now().UTC().Format(time.UnixDate) + "\n"
+	if err := os.WriteFile(e.restartPending, []byte(record), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := e.apply(t)
+	e.assertProceeded(t, err)
+	mustNotExist(t, e.restartPending, "install.sh-format restart-pending from a dead installer")
+}

--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -120,28 +120,53 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 			}
 		}
 
-		if _, err := os.Stat(restartPendingInterlockFilePath); err == nil {
-			// check the restart pending interlock file to see if we've passed our threshold for blocking
-			fileContents, err := os.ReadFile(restartPendingInterlockFilePath)
-			if err != nil {
-				return output, fmt.Errorf("unable to read restart pending interlock file %s: %w", restartPendingInterlockFilePath, err)
-			}
-			// Parse the time out of the file and determine if we have passed our time threshold
-			t, err := time.Parse(time.UnixDate, string(fileContents))
-			if err != nil {
-				// If we are unable to parse the first observed time out of the file, write "now" as the first observed time of the file.
-				if err := os.WriteFile(restartPendingInterlockFilePath, []byte(nowUnixTimeString), 0600); err != nil {
+		if contents, err := os.ReadFile(restartPendingInterlockFilePath); err == nil {
+			owner, ok := parseInterlockOwner(contents)
+			switch {
+			case ok && !owner.isAlive():
+				// The installer that created this is gone — it was killed between
+				// creating the file and its final rm. Clear it rather than serving
+				// out the full restartPendingTimeout.
+				logrus.Warnf("[Applyinator] removing restart pending interlock file %s left by dead pid %d", restartPendingInterlockFilePath, owner.PID)
+				if err := os.Remove(restartPendingInterlockFilePath); err != nil && !os.IsNotExist(err) {
+					logrus.Errorf("error encountered while removing restart pending interlock file %s: %v", restartPendingInterlockFilePath, err)
+				}
+			case ok && owner.Written.IsZero():
+				// Owner is alive but the file carries no usable timestamp, so the
+				// timeout has no defined start. Stamp our own observation time —
+				// preserving the owner fields so liveness still works — and block.
+				stamped := owner
+				stamped.Written = now
+				if err := os.WriteFile(restartPendingInterlockFilePath, stamped.marshal(), 0600); err != nil {
 					return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFilePath, err)
 				}
 				return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", restartPendingTimeout.String())
-			}
-			if now.Before(t.Add(restartPendingTimeout)) {
-				return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", t.Add(restartPendingTimeout).Sub(now).String())
-			}
-			// remove the restart pending file
-			err = os.Remove(restartPendingInterlockFilePath)
-			if err != nil {
-				logrus.Errorf("error encountered while removing restart pending interlock file %s: %v", restartPendingInterlockFilePath, err)
+			case ok && now.Before(owner.Written.Add(restartPendingTimeout)):
+				return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", owner.Written.Add(restartPendingTimeout).Sub(now).String())
+			case ok:
+				// A live installer cannot block applies forever: past the cap, force through.
+				logrus.Warnf("[Applyinator] restart pending interlock file %s exceeded %s; ignoring", restartPendingInterlockFilePath, restartPendingTimeout)
+				if err := os.Remove(restartPendingInterlockFilePath); err != nil && !os.IsNotExist(err) {
+					logrus.Errorf("error encountered while removing restart pending interlock file %s: %v", restartPendingInterlockFilePath, err)
+				}
+			default:
+				// Legacy format (bare timestamp, or an empty `touch`) — unchanged
+				// behaviour, for an old install.sh against a new binary.
+				t, err := time.Parse(time.UnixDate, string(contents))
+				if err != nil {
+					// If we are unable to parse the first observed time out of the file, write "now" as the first observed time of the file.
+					if err := os.WriteFile(restartPendingInterlockFilePath, []byte(nowUnixTimeString), 0600); err != nil {
+						return output, fmt.Errorf("unable to write first-observed time to restart pending interlock file %s: %w", restartPendingInterlockFilePath, err)
+					}
+					return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", restartPendingTimeout.String())
+				}
+				if now.Before(t.Add(restartPendingTimeout)) {
+					return output, fmt.Errorf("restart is pending for system-agent, waiting %s until ignoring pending restart", t.Add(restartPendingTimeout).Sub(now).String())
+				}
+				// remove the restart pending file
+				if err := os.Remove(restartPendingInterlockFilePath); err != nil {
+					logrus.Errorf("error encountered while removing restart pending interlock file %s: %v", restartPendingInterlockFilePath, err)
+				}
 			}
 		}
 

--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -481,6 +481,31 @@ func (a *Applyinator) writePlanToDisk(now time.Time, plan *CalculatedPlan) error
 	return writeContentToFile(filepath.Join(a.appliedPlanDir, file), os.Getuid(), os.Getgid(), 0600, anpString)
 }
 
+// Drain blocks until any in-flight Apply completes or ctx expires, then
+// guarantees the active interlock file is gone. Call it after the top-level
+// context is cancelled so a SIGTERM does not leave an interlock behind.
+func (a *Applyinator) Drain(ctx context.Context) {
+	if a.interlockDir == "" {
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		close(done)
+	}()
+	select {
+	case <-done:
+		logrus.Debugf("[Applyinator] drain complete, no apply in flight")
+	case <-ctx.Done():
+		logrus.Warnf("[Applyinator] drain timed out waiting for in-flight apply; clearing active interlock anyway")
+	}
+	path := filepath.Join(a.interlockDir, applyinatorActiveInterlockFile)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		logrus.Errorf("unable to remove applyinator active interlock file %s during drain: %v", path, err)
+	}
+}
+
 func (a *Applyinator) execute(ctx context.Context, prefix, executionDir string, instruction planapi.CommonInstruction, combinedOutput bool, attempt int) ([]byte, []byte, int, error) {
 	if instruction.Image == "" {
 		logrus.Infof("[Applyinator] No image provided, creating empty working directory %s", executionDir)

--- a/pkg/applyinator/applyinator.go
+++ b/pkg/applyinator/applyinator.go
@@ -107,10 +107,15 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 	if a.interlockDir != "" {
 		restartPendingInterlockFilePath := filepath.Join(a.interlockDir, restartPendingInterlockFile)
 		applyinatorActiveInterlockFilePath := filepath.Join(a.interlockDir, applyinatorActiveInterlockFile)
-		// First off, remove check and remove the active interlock as the applyinator is not actually active
-		if _, err := os.Stat(applyinatorActiveInterlockFile); err == nil {
-			err = os.Remove(applyinatorActiveInterlockFile)
-			if err != nil {
+		// First off, check and remove the active interlock as the applyinator is not actually active.
+		// The file is only meaningful while its writer is still running: this process is the only
+		// thing that creates it, so anything found here was left by an agent that no longer exists.
+		if contents, err := os.ReadFile(applyinatorActiveInterlockFilePath); err == nil {
+			if owner, ok := parseInterlockOwner(contents); ok && owner.PID != os.Getpid() && owner.isAlive() {
+				return output, fmt.Errorf("another system-agent process (pid %d) is applying a plan; refusing to apply concurrently", owner.PID)
+			}
+			logrus.Warnf("[Applyinator] removing stale active interlock file %s left by a previous agent", applyinatorActiveInterlockFilePath)
+			if err := os.Remove(applyinatorActiveInterlockFilePath); err != nil && !os.IsNotExist(err) {
 				logrus.Errorf("unable to remove applyinator active interlock file %s: %v", applyinatorActiveInterlockFilePath, err)
 			}
 		}
@@ -141,7 +146,7 @@ func (a *Applyinator) Apply(ctx context.Context, input ApplyInput) (ApplyOutput,
 		}
 
 		// At this point, there is no restart-pending and we can continue with applyinator reconciliation, so create the applyinator-active file
-		err := os.WriteFile(applyinatorActiveInterlockFilePath, []byte(nowUnixTimeString), 0600)
+		err := os.WriteFile(applyinatorActiveInterlockFilePath, newInterlockOwner(now).marshal(), 0600)
 		if err != nil {
 			logrus.Errorf("unable to write applyinator active interlock file %s: %v", applyinatorActiveInterlockFilePath, err)
 		}

--- a/pkg/applyinator/drain_test.go
+++ b/pkg/applyinator/drain_test.go
@@ -1,0 +1,105 @@
+package applyinator
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDrainRemovesLeakedInterlock(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.active, newInterlockOwner(time.Now()))
+
+	e.a.Drain(context.Background())
+	mustNotExist(t, e.active, "interlock after drain")
+}
+
+func TestDrainIsANoOpWhenNothingToClean(t *testing.T) {
+	e := newTestEnv(t)
+	e.a.Drain(context.Background()) // must not panic on a missing file
+	mustNotExist(t, e.active, "interlock after drain")
+}
+
+// TestDrainWithoutInterlockDir: interlocks are optional, and Drain runs on every
+// shutdown path.
+func TestDrainWithoutInterlockDir(t *testing.T) {
+	a := NewApplyinator(t.TempDir(), false, "", "", nil)
+	a.Drain(context.Background()) // must not panic
+}
+
+// TestDrainWaitsForInFlightApply is the point of the drain: on SIGTERM an apply
+// may still be running, and its deferred cleanup must be allowed to land rather
+// than the process exiting out from under it.
+func TestDrainWaitsForInFlightApply(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.active, newInterlockOwner(time.Now()))
+
+	// Stand in for an in-flight Apply, which holds a.mu for its duration.
+	e.a.mu.Lock()
+
+	drained := make(chan struct{})
+	go func() {
+		e.a.Drain(context.Background())
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		e.a.mu.Unlock()
+		t.Fatal("Drain returned while an apply was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The "apply" finishes and removes its own interlock, as the defer in Apply
+	// does; Drain must then return promptly.
+	if err := os.Remove(e.active); err != nil {
+		t.Fatal(err)
+	}
+	e.a.mu.Unlock()
+
+	select {
+	case <-drained:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Drain did not return after the in-flight apply completed")
+	}
+	mustNotExist(t, e.active, "interlock after drain")
+}
+
+// TestDrainTimesOutAndClearsAnyway: wrangler hard-exits on a second SIGTERM, so
+// the drain must be bounded and must still clear the file when it gives up.
+func TestDrainTimesOutAndClearsAnyway(t *testing.T) {
+	e := newTestEnv(t)
+	writeOwner(t, e.active, newInterlockOwner(time.Now()))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	e.a.mu.Lock()
+	go func() {
+		defer wg.Done()
+		time.Sleep(2 * time.Second)
+		e.a.mu.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		e.a.Drain(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Errorf("Drain took %v, want it bounded by the 50ms context deadline", elapsed)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Drain did not honour its context deadline")
+	}
+	mustNotExist(t, e.active, "interlock after a timed-out drain")
+	wg.Wait()
+}

--- a/pkg/applyinator/installsh_restart_pending_test.go
+++ b/pkg/applyinator/installsh_restart_pending_test.go
@@ -1,0 +1,105 @@
+package applyinator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestInstallShWriteInterlockOwnerIsParseable is the cross-language contract
+// test. install.sh writes restart-pending and the agent reads it; if the format
+// drifts, parseInterlockOwner silently returns ok=false and the agent falls back
+// to the legacy five-minute path — the exact behaviour the fix removes, with no
+// visible error to say so.
+func TestInstallShWriteInterlockOwnerIsParseable(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "restart-pending")
+
+	out, err := runInstallShFunc(t, nil,
+		fmt.Sprintf("write_interlock_owner %q\necho \"SHELLPID=$$\"", target))
+	if err != nil {
+		t.Fatalf("write_interlock_owner failed: %v\n%s", err, out)
+	}
+
+	contents, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("write_interlock_owner produced no file: %v\n%s", err, out)
+	}
+
+	owner, ok := parseInterlockOwner(contents)
+	if !ok {
+		t.Fatalf("the agent cannot parse what install.sh writes:\n%q", contents)
+	}
+
+	// The shell's PID must round-trip, so the agent can test its liveness.
+	var wantPID int
+	for _, line := range strings.Split(out, "\n") {
+		if rest, found := strings.CutPrefix(strings.TrimSpace(line), "SHELLPID="); found {
+			wantPID, _ = strconv.Atoi(rest)
+		}
+	}
+	if wantPID == 0 {
+		t.Fatalf("harness did not report the shell PID:\n%s", out)
+	}
+	if owner.PID != wantPID {
+		t.Errorf("pid = %d, want the installer's pid %d", owner.PID, wantPID)
+	}
+
+	if owner.BootID == "" && currentBootID() != "" {
+		t.Error("install.sh wrote no boot id, so the agent loses its across-reboot guard")
+	}
+	if owner.BootID != currentBootID() {
+		t.Errorf("boot id = %q, want %q", owner.BootID, currentBootID())
+	}
+
+	// A timestamp that does not parse leaves the restart-pending window with no
+	// defined start.
+	if owner.Written.IsZero() {
+		t.Errorf("install.sh wrote a timestamp the agent cannot parse:\n%q", contents)
+	} else if skew := time.Since(owner.Written); skew < -2*time.Minute || skew > 2*time.Minute {
+		// Catches a zone written in a form Go resolves to the wrong offset.
+		t.Errorf("timestamp is %v away from now; the zone did not round-trip:\n%q", skew, contents)
+	}
+
+	// install.sh deliberately writes no start= field; the agent must treat that
+	// as "unknown" rather than as a mismatch.
+	if owner.Start != 0 {
+		t.Errorf("start = %d, want 0 — install.sh should not write one", owner.Start)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("permissions = %04o, want 0600", perm)
+	}
+
+	// The installer is gone by now, so the agent must consider the file stale.
+	if owner.isAlive() {
+		t.Error("owner reports alive after the installer shell exited")
+	}
+}
+
+// TestInstallShTrapsRestartPending: every fatal between creating restart-pending
+// and the final rm previously leaked it. The trap is what closes that.
+func TestInstallShTrapsRestartPending(t *testing.T) {
+	contents, err := os.ReadFile(installShPath)
+	if err != nil {
+		t.Skipf("install.sh not readable: %v", err)
+	}
+	script := string(contents)
+	if strings.Contains(script, "touch ${CATTLE_AGENT_VAR_DIR}/interlock/restart-pending") {
+		t.Error("restart-pending is still created with a bare touch, so it carries no owner")
+	}
+	if !strings.Contains(script, "write_interlock_owner ${CATTLE_AGENT_VAR_DIR}/interlock/restart-pending") {
+		t.Error("restart-pending is not owner-stamped")
+	}
+	if !strings.Contains(script, "trap 'rm -f ${CATTLE_AGENT_VAR_DIR}/interlock/restart-pending' EXIT INT TERM") {
+		t.Error("no EXIT/INT/TERM trap on restart-pending: a fatal between creation and the final rm leaks it")
+	}
+}

--- a/pkg/applyinator/installsh_test.go
+++ b/pkg/applyinator/installsh_test.go
@@ -1,0 +1,164 @@
+package applyinator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// installShPath is the installer whose interlock handling must stay in step with
+// this package. The two write and read the same on-disk format, in two
+// languages, with no shared definition — so it is pinned by test.
+const installShPath = "../../install.sh"
+
+// runInstallShFunc evaluates install.sh up to (but not including) do_install,
+// which defines its helper functions without running the installer, then invokes
+// the given snippet. Returns combined output.
+func runInstallShFunc(t *testing.T, env []string, snippet string) (string, error) {
+	t.Helper()
+	if _, err := os.Stat(installShPath); err != nil {
+		t.Skipf("install.sh not found at %s: %v", installShPath, err)
+	}
+	abs, err := filepath.Abs(installShPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	harness := fmt.Sprintf(`
+set -e
+eval "$(sed '/^do_install/,$d' %q)"
+%s
+`, abs, snippet)
+
+	cmd := exec.Command("sh", "-c", harness)
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// TestInstallShEnsureApplyinatorNotActiveDeadOwner: the five-minute wait was the
+// user-visible cost of the leaked interlock. A dead owner must short-circuit it.
+func TestInstallShEnsureApplyinatorNotActiveDeadOwner(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(dir, "interlock", "applyinator-active")
+	writeOwner(t, active, deadOwner(t))
+
+	start := time.Now()
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"ensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("took %v; a dead owner must not be waited on", elapsed)
+	}
+	if !strings.Contains(out, "no longer running") {
+		t.Errorf("expected the stale-owner message, got:\n%s", out)
+	}
+	mustNotExist(t, active, "stale interlock after ensure_applyinator_not_active")
+}
+
+func TestInstallShEnsureApplyinatorNotActiveNoFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"ensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("took %v; with no interlock file it must return immediately", elapsed)
+	}
+	if strings.Contains(out, "Active plan reconciliation detected") {
+		t.Errorf("slept despite there being no interlock file:\n%s", out)
+	}
+}
+
+// TestInstallShEnsureApplyinatorNotActiveLiveOwner: a genuinely running apply
+// must still be waited on, and the wait must still terminate.
+func TestInstallShEnsureApplyinatorNotActiveLiveOwner(t *testing.T) {
+	if testing.Short() {
+		t.Skip("takes ~5s waiting on the live owner")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(dir, "interlock", "applyinator-active")
+	writeOwner(t, active, liveOwner(t))
+
+	// Two iterations rather than the production 60, to keep the test to one sleep.
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"APPLYINATOR_ACTIVE_WAIT_COUNT=2\nensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Active plan reconciliation detected") {
+		t.Errorf("expected it to wait on the live owner, got:\n%s", out)
+	}
+	if !strings.Contains(out, "after timeout") {
+		t.Errorf("expected the timeout message, got:\n%s", out)
+	}
+	mustNotExist(t, active, "interlock after the wait timed out")
+}
+
+// TestInstallShEnsureApplyinatorNotActiveLegacyFile: an empty file from an older
+// install.sh carries no PID, so the installer cannot test liveness and must fall
+// back to waiting out the timeout rather than deleting a possibly-live holder's
+// interlock immediately.
+func TestInstallShEnsureApplyinatorNotActiveLegacyFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("takes ~5s waiting out the timeout")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "interlock"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(dir, "interlock", "applyinator-active")
+	if err := os.WriteFile(active, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runInstallShFunc(t,
+		[]string{"CATTLE_AGENT_VAR_DIR=" + dir},
+		"APPLYINATOR_ACTIVE_WAIT_COUNT=2\nensure_applyinator_not_active")
+	if err != nil {
+		t.Fatalf("ensure_applyinator_not_active failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Active plan reconciliation detected") {
+		t.Errorf("expected it to wait on a legacy file with no pid, got:\n%s", out)
+	}
+	mustNotExist(t, active, "legacy interlock after the wait timed out")
+}
+
+// TestInstallShServiceUnitClearsInterlock pins the ExecStartPre backstop. It is
+// what covers a recycled PID across an agent restart, so its absence would be a
+// silent regression.
+func TestInstallShServiceUnitClearsInterlock(t *testing.T) {
+	contents, err := os.ReadFile(installShPath)
+	if err != nil {
+		t.Skipf("install.sh not readable: %v", err)
+	}
+	unit := string(contents)
+	if !strings.Contains(unit, "ExecStartPre=-/bin/rm -f ${CATTLE_AGENT_VAR_DIR}/interlock/applyinator-active") {
+		t.Error("the generated systemd unit no longer clears applyinator-active before starting the agent")
+	}
+	// The leading "-" makes a missing /bin/rm non-fatal for the unit.
+	if !strings.Contains(unit, "ExecStartPre=-") {
+		t.Error("ExecStartPre is not prefixed with '-', so a missing /bin/rm would fail the unit")
+	}
+}

--- a/pkg/applyinator/interlock.go
+++ b/pkg/applyinator/interlock.go
@@ -1,0 +1,129 @@
+package applyinator
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const bootIDPath = "/proc/sys/kernel/random/boot_id"
+
+// interlockOwner identifies the process that created an interlock file, so a
+// later process can distinguish a live holder from one that was killed.
+type interlockOwner struct {
+	PID     int
+	BootID  string
+	Written time.Time
+	Start   uint64
+}
+
+func newInterlockOwner(now time.Time) interlockOwner {
+	pid := os.Getpid()
+	return interlockOwner{PID: pid, BootID: currentBootID(), Start: procStartTime(pid), Written: now}
+}
+
+// procStartTime returns field 22 of /proc/<pid>/stat — the process start time in
+// clock ticks since boot. Zero means unavailable, in which case callers fall
+// back to PID-only liveness.
+func procStartTime(pid int) uint64 {
+	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0
+	}
+	s := string(b)
+	i := strings.LastIndexByte(s, ')')
+	if i < 0 {
+		return 0
+	}
+	f := strings.Fields(s[i+1:])
+	if len(f) < 20 {
+		return 0
+	}
+	n, err := strconv.ParseUint(f[19], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func currentBootID() string {
+	b, err := os.ReadFile(bootIDPath)
+	if err != nil {
+		return "" // non-Linux or restricted /proc: degrade to PID-only liveness
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func (o interlockOwner) marshal() []byte {
+	return []byte(fmt.Sprintf("pid=%d\nboot=%s\nstart=%d\ntime=%s\n",
+		o.PID, o.BootID, o.Start, o.Written.UTC().Format(time.UnixDate)))
+}
+
+// parseInterlockOwner reports ok=false for any file it does not recognise —
+// including the empty file written by `touch` in an older install.sh and the
+// bare timestamp written by system-agent <= v0.3.16. Callers must keep the
+// legacy path for those.
+func parseInterlockOwner(contents []byte) (interlockOwner, bool) {
+	var o interlockOwner
+	var sawPID bool
+	s := bufio.NewScanner(strings.NewReader(string(contents)))
+	for s.Scan() {
+		k, v, found := strings.Cut(strings.TrimSpace(s.Text()), "=")
+		if !found {
+			continue
+		}
+		switch k {
+		case "pid":
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return interlockOwner{}, false
+			}
+			o.PID, sawPID = n, true
+		case "boot":
+			o.BootID = v
+		case "start":
+			if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+				o.Start = n
+			}
+		case "time":
+			if t, err := time.Parse(time.UnixDate, v); err == nil {
+				o.Written = t
+			}
+		}
+	}
+	return o, sawPID
+}
+
+// isAlive reports whether the writing process is still running. A boot ID that
+// differs from the current one means the file predates a reboot, so the PID —
+// which recycles across reboots — must not be trusted.
+func (o interlockOwner) isAlive() bool {
+	if cur := currentBootID(); cur != "" && o.BootID != "" && cur != o.BootID {
+		return false
+	}
+	if o.PID <= 0 {
+		return false
+	}
+	if o.PID == os.Getpid() {
+		return true
+	}
+	p, err := os.FindProcess(o.PID)
+	if err != nil {
+		return false
+	}
+	if p.Signal(syscall.Signal(0)) != nil {
+		return false
+	}
+	// PIDs recycle within a single boot. If we recorded the owner's start time,
+	// a mismatch means a different process is wearing the same PID.
+	if o.Start != 0 {
+		if cur := procStartTime(o.PID); cur != 0 && cur != o.Start {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/applyinator/interlock_test.go
+++ b/pkg/applyinator/interlock_test.go
@@ -1,0 +1,356 @@
+package applyinator
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// spawnLiveProcess starts a child that stays alive for the duration of the test
+// and returns its PID. Using a real process rather than os.Getpid() exercises
+// the FindProcess/Signal path instead of the same-process short circuit.
+func spawnLiveProcess(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unable to start helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// spawnDeadPID starts a child, waits for it to exit, and returns its PID. The
+// PID is reaped, so it is genuinely gone rather than merely improbable.
+func spawnDeadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unable to start helper process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("helper process did not exit cleanly: %v", err)
+	}
+	return pid
+}
+
+func TestMarshalParseRoundtrip(t *testing.T) {
+	owner := newInterlockOwner(time.Now())
+	if owner.PID != os.Getpid() {
+		t.Fatalf("newInterlockOwner recorded pid %d, want %d", owner.PID, os.Getpid())
+	}
+
+	parsed, ok := parseInterlockOwner(owner.marshal())
+	if !ok {
+		t.Fatal("parseInterlockOwner returned ok=false for a freshly marshalled owner")
+	}
+	if parsed.PID != owner.PID {
+		t.Errorf("PID mismatch: got %d, want %d", parsed.PID, owner.PID)
+	}
+	if parsed.BootID != owner.BootID {
+		t.Errorf("BootID mismatch: got %q, want %q", parsed.BootID, owner.BootID)
+	}
+	if parsed.Start != owner.Start {
+		t.Errorf("Start mismatch: got %d, want %d", parsed.Start, owner.Start)
+	}
+	// UnixDate has second granularity, so compare truncated instants.
+	if want := owner.Written.Truncate(time.Second); !parsed.Written.Equal(want) {
+		t.Errorf("Written mismatch: got %v, want %v", parsed.Written.UTC(), want.UTC())
+	}
+}
+
+// TestMarshalWritesUTC guards the round-trip against local zone abbreviations.
+// time.Parse resolves an abbreviation it does not know to a zero offset, so
+// formatting in local time would decode to the wrong instant on most nodes.
+func TestMarshalWritesUTC(t *testing.T) {
+	// A zone with a non-UTC offset whose abbreviation Go cannot resolve on parse.
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	written := time.Date(2026, 7, 14, 9, 48, 43, 0, loc)
+	owner := interlockOwner{PID: 23056, BootID: "boot", Start: 99, Written: written}
+
+	raw := string(owner.marshal())
+	if !strings.Contains(raw, " UTC ") {
+		t.Errorf("marshalled timestamp is not in UTC: %q", raw)
+	}
+
+	parsed, ok := parseInterlockOwner([]byte(raw))
+	if !ok {
+		t.Fatal("parseInterlockOwner returned ok=false")
+	}
+	if !parsed.Written.Equal(written) {
+		t.Errorf("round-trip changed the instant: got %v, want %v", parsed.Written.UTC(), written.UTC())
+	}
+}
+
+func TestParseInterlockOwner(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		wantOK   bool
+		wantPID  int
+		wantBoot string
+		wantStrt uint64
+	}{
+		{
+			name:     "full record written by the agent",
+			contents: "pid=23056\nboot=abc-123\nstart=456\ntime=Mon Jul 14 09:48:43 UTC 2026\n",
+			wantOK:   true, wantPID: 23056, wantBoot: "abc-123", wantStrt: 456,
+		},
+		{
+			// install.sh writes no start= field; the agent must still accept it.
+			name:     "install.sh record without start",
+			contents: "pid=4242\nboot=abc-123\ntime=Mon Jul 14 09:48:43 UTC 2026\n",
+			wantOK:   true, wantPID: 4242, wantBoot: "abc-123", wantStrt: 0,
+		},
+		{
+			name:     "empty file from a legacy touch",
+			contents: "",
+			wantOK:   false,
+		},
+		{
+			name:     "bare timestamp from system-agent <= v0.3.16",
+			contents: "Mon Jul 14 09:48:43 CEST 2026",
+			wantOK:   false,
+		},
+		{
+			name:     "no pid key",
+			contents: "boot=abc-123\ntime=Mon Jul 14 09:48:43 UTC 2026\n",
+			wantOK:   false,
+		},
+		{
+			name:     "non-numeric pid",
+			contents: "pid=notanumber\nboot=abc-123\n",
+			wantOK:   false,
+		},
+		{
+			name:     "unknown keys are ignored",
+			contents: "pid=7\nfuture=value\nboot=b\n",
+			wantOK:   true, wantPID: 7, wantBoot: "b",
+		},
+		{
+			name:     "unparseable time leaves Written zero but still parses",
+			contents: "pid=7\nboot=b\ntime=not a date\n",
+			wantOK:   true, wantPID: 7, wantBoot: "b",
+		},
+		{
+			name:     "unparseable start is ignored",
+			contents: "pid=7\nstart=notanumber\n",
+			wantOK:   true, wantPID: 7, wantStrt: 0,
+		},
+		{
+			name:     "surrounding whitespace is tolerated",
+			contents: "  pid=7  \n\tboot=b\t\n",
+			wantOK:   true, wantPID: 7, wantBoot: "b",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseInterlockOwner([]byte(tc.contents))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.PID != tc.wantPID {
+				t.Errorf("PID = %d, want %d", got.PID, tc.wantPID)
+			}
+			if got.BootID != tc.wantBoot {
+				t.Errorf("BootID = %q, want %q", got.BootID, tc.wantBoot)
+			}
+			if got.Start != tc.wantStrt {
+				t.Errorf("Start = %d, want %d", got.Start, tc.wantStrt)
+			}
+		})
+	}
+}
+
+// TestParseUnparseableTimeLeavesWrittenZero pins the signal Apply relies on to
+// decide it must stamp its own observation time onto restart-pending.
+func TestParseUnparseableTimeLeavesWrittenZero(t *testing.T) {
+	got, ok := parseInterlockOwner([]byte("pid=7\nboot=b\ntime=not a date\n"))
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if !got.Written.IsZero() {
+		t.Errorf("Written = %v, want the zero time", got.Written)
+	}
+}
+
+func TestIsAliveSelf(t *testing.T) {
+	if !newInterlockOwner(time.Now()).isAlive() {
+		t.Error("current process should report as alive")
+	}
+}
+
+func TestIsAliveLiveChildProcess(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	owner := interlockOwner{PID: pid, BootID: currentBootID(), Start: procStartTime(pid)}
+	if !owner.isAlive() {
+		t.Errorf("live child pid %d should report as alive", pid)
+	}
+}
+
+func TestIsAliveDeadPID(t *testing.T) {
+	pid := spawnDeadPID(t)
+	owner := interlockOwner{PID: pid, BootID: currentBootID()}
+	if owner.isAlive() {
+		t.Errorf("reaped pid %d should not be reported as alive", pid)
+	}
+}
+
+func TestIsAliveOutOfRangePID(t *testing.T) {
+	// Above /proc/sys/kernel/pid_max on any realistic system.
+	owner := interlockOwner{PID: 99999999, BootID: currentBootID()}
+	if owner.isAlive() {
+		t.Error("non-existent PID should not be reported as alive")
+	}
+}
+
+// TestIsAliveRejectsNonPositivePID: os.Process.Signal happens to reject 0 and -1
+// on its own, so these cases are a guard against that changing.
+func TestIsAliveRejectsNonPositivePID(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		owner := interlockOwner{PID: pid, BootID: currentBootID()}
+		if owner.isAlive() {
+			t.Errorf("pid %d should not be reported as alive", pid)
+		}
+	}
+}
+
+// TestIsAliveRejectsNegativePIDOfLiveProcessGroup is the case the stdlib does
+// not cover: kill(-N, sig) addresses process *group* N, so a corrupt interlock
+// file holding a negative PID that happens to match a live process group would
+// be read as a live owner — wedging the agent permanently against a plan nobody
+// is applying.
+func TestIsAliveRejectsNegativePIDOfLiveProcessGroup(t *testing.T) {
+	cmd := exec.Command("sleep", "300")
+	// Put the child in its own process group, so its PGID equals its PID.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("unable to start helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Skipf("unable to determine process group: %v", err)
+	}
+	if err := syscall.Kill(-pgid, 0); err != nil {
+		t.Skipf("process group %d is not signalable: %v", pgid, err)
+	}
+
+	owner := interlockOwner{PID: -pgid, BootID: currentBootID()}
+	if owner.isAlive() {
+		t.Errorf("pid %d addresses a live process group and must not be read as a live owner", -pgid)
+	}
+}
+
+func TestIsAliveBootIDMismatch(t *testing.T) {
+	if currentBootID() == "" {
+		t.Skip("boot id unavailable on this system")
+	}
+	pid := spawnLiveProcess(t)
+	owner := interlockOwner{PID: pid, BootID: "00000000-0000-0000-0000-000000000000"}
+	if owner.isAlive() {
+		t.Error("a file from a previous boot must be treated as stale even when the PID is live")
+	}
+}
+
+// TestIsAliveMissingBootIDDegradesToPID covers a file written where /proc was
+// unreadable, and the mixed-version case of an install.sh that wrote no boot id.
+func TestIsAliveMissingBootIDDegradesToPID(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	if !(interlockOwner{PID: pid, BootID: ""}).isAlive() {
+		t.Error("empty boot id should fall back to PID-only liveness, not fail closed")
+	}
+	dead := spawnDeadPID(t)
+	if (interlockOwner{PID: dead, BootID: ""}).isAlive() {
+		t.Error("empty boot id with a dead PID should still report dead")
+	}
+}
+
+// TestIsAliveStartTimeMismatch is the PID-reuse guard: a different process
+// wearing a recycled PID within the same boot must not be mistaken for the
+// interlock's owner.
+func TestIsAliveStartTimeMismatch(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	actual := procStartTime(pid)
+	if actual == 0 {
+		t.Skip("/proc start time unavailable on this system")
+	}
+	owner := interlockOwner{PID: pid, BootID: currentBootID(), Start: actual + 1}
+	if owner.isAlive() {
+		t.Error("start time mismatch should be treated as a recycled PID, not a live owner")
+	}
+}
+
+func TestIsAliveStartTimeZeroSkipsCheck(t *testing.T) {
+	pid := spawnLiveProcess(t)
+	owner := interlockOwner{PID: pid, BootID: currentBootID(), Start: 0}
+	if !owner.isAlive() {
+		t.Error("a missing start time must degrade to PID-only liveness, not fail closed")
+	}
+}
+
+func TestProcStartTime(t *testing.T) {
+	self := procStartTime(os.Getpid())
+	if self == 0 {
+		t.Skip("/proc start time unavailable on this system")
+	}
+	if again := procStartTime(os.Getpid()); again != self {
+		t.Errorf("start time is not stable: %d then %d", self, again)
+	}
+	if got := procStartTime(99999999); got != 0 {
+		t.Errorf("start time for a non-existent pid = %d, want 0", got)
+	}
+	// A distinct process started later must have a different start time,
+	// otherwise the PID-reuse guard has no discriminating power.
+	child := spawnLiveProcess(t)
+	if got := procStartTime(child); got == 0 {
+		t.Errorf("start time for live child pid %d = 0", child)
+	}
+}
+
+// TestProcStartTimeCommWithSpaces covers the parsing hazard in /proc/<pid>/stat:
+// field 2 is the executable name in parentheses and may itself contain spaces
+// and ')', so fields must be counted from the last ')' rather than split naively.
+func TestProcStartTimeCommWithSpaces(t *testing.T) {
+	// Field 22 (index 19 after the final ')') is 4242.
+	fields := make([]string, 0, 30)
+	for i := 3; i <= 30; i++ {
+		if i == 22 {
+			fields = append(fields, "4242")
+			continue
+		}
+		fields = append(fields, fmt.Sprintf("%d", i))
+	}
+	stat := "1234 (weird ) name) S " + strings.Join(fields[1:], " ")
+
+	// Exercise the same slicing procStartTime performs.
+	i := strings.LastIndexByte(stat, ')')
+	if i < 0 {
+		t.Fatal("test fixture has no ')'")
+	}
+	f := strings.Fields(stat[i+1:])
+	if len(f) < 20 {
+		t.Fatalf("fixture produced only %d fields", len(f))
+	}
+	if f[19] != "4242" {
+		t.Errorf("field 22 = %q, want %q — comm containing ')' broke field counting", f[19], "4242")
+	}
+}


### PR DESCRIPTION
**Read PR part A and B to better understand the changes**: https://github.com/rancher/system-agent/pull/429 and https://github.com/rancher/system-agent/pull/430 
## Issue:  https://github.com/rancher/system-agent/issues/403

**PR A** and **PR B** make a leaked interlock *recoverable*. This PR stops it leaking in the first place on the ordinary shutdown path — the one that happens on every `systemctl restart`, and therefore the common case rather than the crash case.

## Problem

`Apply` removes `interlock/applyinator-active` in a `defer`, but nothing kept the process alive long enough for that `defer` to run. `main.go:127` returned as soon as `topContext` was cancelled:

```go
<-topContext.Done()
return nil
```

A `SIGTERM` arriving mid-apply therefore raced the cleanup, and on a `systemctl restart` the exit usually won. The next `install.sh` then found a file whose owner was already gone — the state PRs A and B exist to recover from.

## Solution

`Applyinator.Drain(ctx)` waits for any in-flight `Apply` — by taking `a.mu`, the same mutex `Apply` holds for its entire duration — and then guarantees the file is gone. `main.go` calls it after `<-topContext.Done()`.

Three properties worth review attention:

**It is bounded.** wrangler hard-exits on a second signal, so an open-ended wait would simply be killed. Hence the 30s cap.

**It runs on its own context.** `topContext` is already cancelled at the call site, so deriving from it would expire immediately and defeat the wait. `context.Background()` with an explicit timeout is deliberate.

**It clears the file on both paths, including timeout.** Giving up on the wait is precisely when the interlock is most likely to be stranded, so the removal sits after the `select`, not inside the success arm.

`Drain` is a no-op when `interlockDir` is empty, since interlocks are optional but shutdown is not.

This does **not** replace the self-heal in PRs A and B, which still covers `SIGKILL`, OOM and power loss. It removes the case that does not need to reach them.

### Alternatives considered

**Register the drain as a wrangler `OnShutdown` hook.** Would keep `main.go` untouched, but ordering against the controller factory's own shutdown is not guaranteed, and the drain must run after the watchers stop enqueuing work.

**Widen the `defer` in `Apply` to catch signals directly.** Signal handling belongs at the top level; `Apply` has no business installing handlers, and it would not help when the process exits from a different goroutine.

**Make the timeout configurable.** 30s is well inside systemd's default `TimeoutStopSec=90s`. A knob invites a value that exceeds it, at which point systemd `SIGKILL`s and the drain is worse than useless. Left as a constant.

### Known limitations

- Only covers *graceful* shutdown. `SIGKILL`, OOM and power loss still leak the file, by construction — that is what PRs A and B are for.
- If an apply legitimately runs longer than 30s (common: RKE2 upgrades), the drain times out and clears the interlock while the apply is still running. This is the right trade — the process is going away regardless, and a stranded file is the worse outcome — but it means the interlock is not a hard guarantee during shutdown.
- Adds up to 30s to `systemctl stop` when an apply is in flight. Well within `TimeoutStopSec`, but it is a visible change in shutdown time.

#### Manual Testing

Use the harness in `PR-A-owner-stamped-interlock.md`, with `git checkout fix-c-graceful-drain` (which includes A and B).

**C1 — The leak, before and after.** The whole point of the PR.

```sh
# On the parent branch first, to see the leak:
git checkout fix-b-restart-pending-owner && CGO_ENABLED=0 go build -o /usr/local/bin/rancher-system-agent .
rm -f /var/lib/rancher/agent/plans/test.pos
CATTLE_LOGLEVEL=debug rancher-system-agent sentinel &
sleep 10                                      # the 60s sleep instruction is running
ls -l /var/lib/rancher/agent/interlock/       # applyinator-active present
kill -TERM %1 && wait
ls -l /var/lib/rancher/agent/interlock/       # LEAKED

# On this branch:
git checkout fix-c-graceful-drain && CGO_ENABLED=0 go build -o /usr/local/bin/rancher-system-agent .
rm -f /var/lib/rancher/agent/plans/test.pos
CATTLE_LOGLEVEL=debug rancher-system-agent sentinel &
sleep 10
time kill -TERM %1 ; wait
ls -l /var/lib/rancher/agent/interlock/       # gone
```

Expect on this branch: shutdown pauses while the instruction finishes (up to 30s), `drain complete, no apply in flight` at debug level, and no file left behind.

**C2 — The timeout is real.** Make the plan outlast the cap:

```sh
cat > /var/lib/rancher/agent/plans/test.plan <<'EOF'
{"instructions":[{"name":"slow","command":"/bin/sh","args":["-c","sleep 300"],"saveOutput":true}]}
EOF
rm -f /var/lib/rancher/agent/plans/test.pos
CATTLE_LOGLEVEL=debug rancher-system-agent sentinel &
sleep 10
time kill -TERM %1 ; wait
ls -l /var/lib/rancher/agent/interlock/ 
```

Expect: exits after **~30s, not 300**, logs `drain timed out waiting for in-flight apply; clearing active interlock anyway`, and the file is gone regardless.

**C3 — Idle shutdown is not slowed.** `SIGTERM` with no plan in flight should return immediately. Worth timing, since a regression here would add 30s to every restart.

**C4 — `SIGKILL` still leaks, and is still recovered.** Confirms C is additive to A, not a replacement:

```sh
rm -f /var/lib/rancher/agent/plans/test.pos
CATTLE_LOGLEVEL=debug rancher-system-agent sentinel &
sleep 10 && kill -9 %1
ls -l /var/lib/rancher/agent/interlock/      # leaked, expected
rm -f /var/lib/rancher/agent/plans/test.pos
CATTLE_LOGLEVEL=debug rancher-system-agent sentinel   # PR A clears it
```

**C5 — Under systemd**, on a node with the agent installed:

```sh
rm -f /var/lib/rancher/agent/plans/test.pos
systemctl restart rancher-system-agent    # during an active plan apply
ls -l /var/lib/rancher/agent/interlock/
journalctl -u rancher-system-agent | grep -i drain
```

Check `systemctl show rancher-system-agent -p TimeoutStopSec` is comfortably above 30s (default 90s).

**C6 — No interlock configured.** Remove `interlockDirectory` from `config.yaml` and confirm shutdown does not panic.

#### Automated Testing

`pkg/applyinator/drain_test.go` — 5 tests: a leaked interlock is removed; a missing file does not panic; an empty `interlockDir` does not panic; **the drain actually waits** (asserts `Drain` has *not* returned 100ms into a held lock, then returns promptly once released); and the timeout path is bounded by its context deadline *and* still clears the file.

The waiting tests hold `a.mu` directly rather than running a real `Apply`, because executing an instruction chowns the working directory to root and unprivileged runners cannot.

Full suite green: `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`.

### QA Testing Considerations

- The interesting window is **`SIGTERM` arriving mid-apply** — an idle shutdown exercises none of this.
- Time `systemctl stop` and `systemctl restart` both idle and mid-plan; confirm neither approaches `TimeoutStopSec`.
- A long RKE2 upgrade plan will exceed 30s. Confirm the timeout path is clean: agent exits, interlock cleared, next start proceeds.
- Confirm the `SIGKILL` path still leaks *and* still recovers via PR A — C must be additive.

### Regressions Considerations

- **Shutdown latency.** Up to 30s added when an apply is in flight. If any packaging sets `TimeoutStopSec` below that, systemd will `SIGKILL` mid-drain — the interlock then leaks and PR A's self-heal handles it, so the failure is graceful, but the drain would be pointless there.
- **The goroutine taking `a.mu` is never released** if `ctx` expires first; it lives until the in-flight apply finishes, which is immediately before process exit. Harmless here, but it is a deliberate leak rather than an oversight.
- **Ordering in `main.go`.** `Drain` runs after all watchers have been signalled to stop. If a future change starts a watcher that can call `Apply` after `topContext` is cancelled, the drain could clear an interlock belonging to a *starting* apply.
