### PR TITLE
Recover from an out-of-order secret instead of wedging on it

### DIFF
--- a/pkg/k8splan/watcher.go
+++ b/pkg/k8splan/watcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -66,6 +65,12 @@ const (
 
 	enqueueAfterDuration  = "5s"
 	cooldownTimerDuration = "30s"
+
+	// maxConsecutiveStaleReads is how many times in a row a live read may come
+	// back older than the last applied resourceVersion before the agent stops
+	// trusting what it remembers. Consecutive, not cumulative: an in-order event
+	// ends the streak.
+	maxConsecutiveStaleReads = 3
 )
 
 func Watch(ctx context.Context, applyinator applyinator.Applyinator, connInfo config.ConnectionInfo, strictVerify bool) {
@@ -81,6 +86,7 @@ type watcher struct {
 	connInfo                   config.ConnectionInfo
 	applyinator                applyinator.Applyinator
 	lastAppliedResourceVersion string
+	staleReadCount             int
 	secretUID                  string
 }
 
@@ -88,6 +94,57 @@ func toInt(resourceVersion string) int {
 	// we assume this is always a valid number
 	n, _ := strconv.Atoi(resourceVersion)
 	return n
+}
+
+// staleReadAction is what the watcher should do about a secret whose
+// resourceVersion is older than the last one it applied.
+type staleReadAction int
+
+const (
+	// staleRetry means ground truth could not be established: requeue and try
+	// again without engaging the controller's failure rate limiter.
+	staleRetry staleReadAction = iota
+	// staleUseLive means the live read is at least as new as the last applied
+	// resourceVersion, so reconcile against the live object.
+	staleUseLive
+	// staleForceResync means repeated live reads stayed behind. Drop the
+	// remembered resourceVersion and reconcile against the live object anyway,
+	// rather than staying wedged.
+	staleForceResync
+)
+
+func liveResourceVersion(live *corev1.Secret) string {
+	if live == nil {
+		return ""
+	}
+	return live.ResourceVersion
+}
+
+// noteInOrderEvent records that an event arrived in the expected order, ending
+// any run of stale reads. Without this the counter is cumulative rather than
+// consecutive, and three unrelated stale observations over an agent's lifetime
+// would force a resync — which re-runs one-time instructions.
+func (w *watcher) noteInOrderEvent() {
+	w.staleReadCount = 0
+}
+
+// resolveStaleRead decides how to handle an out-of-order secret and advances the
+// consecutive-stale counter. liveRV is ignored when getErr is non-nil.
+func (w *watcher) resolveStaleRead(liveRV string, getErr error) staleReadAction {
+	switch {
+	case getErr != nil:
+		return staleRetry
+	case toInt(liveRV) >= toInt(w.lastAppliedResourceVersion):
+		w.noteInOrderEvent()
+		return staleUseLive
+	case w.staleReadCount+1 >= maxConsecutiveStaleReads:
+		w.staleReadCount = 0
+		w.lastAppliedResourceVersion = ""
+		return staleForceResync
+	default:
+		w.staleReadCount++
+		return staleRetry
+	}
 }
 
 func incrementCount(count []byte) []byte {
@@ -195,10 +252,35 @@ func (w *watcher) start(ctx context.Context, strictVerify bool) {
 			logrus.Infof("[K8s] received secret with new UID (%s, previously %s); secret was recreated — resetting agent state", secret.UID, w.secretUID)
 			w.secretUID = ""
 			w.lastAppliedResourceVersion = ""
+			w.staleReadCount = 0
 			hasRunOnce = false
 		case rvIsOlder:
-			logrus.Errorf("[K8s] received secret to process that was older than the last secret operated on. (%s vs %s)", secret.ResourceVersion, w.lastAppliedResourceVersion)
-			return secret, errors.New("secret received was too old")
+			logrus.Warnf("[K8s] received secret with resource version %s, older than the last applied (%s); confirming with a live read", secret.ResourceVersion, w.lastAppliedResourceVersion)
+			live, getErr := core.Secret().Get(w.connInfo.Namespace, w.connInfo.SecretName, metav1.GetOptions{})
+			if getErr == nil && live == nil {
+				getErr = fmt.Errorf("live read returned a nil secret")
+			}
+			attempt := w.staleReadCount + 1
+			switch w.resolveStaleRead(liveResourceVersion(live), getErr) {
+			case staleUseLive:
+				logrus.Infof("[K8s] live read returned resource version %s; proceeding with it", live.ResourceVersion)
+				originalSecret = live.DeepCopy()
+				secret = live.DeepCopy()
+			case staleForceResync:
+				logrus.Warnf("[K8s] live read still older than last applied after %d attempts; resetting last applied resource version and resyncing", attempt)
+				originalSecret = live.DeepCopy()
+				secret = live.DeepCopy()
+			default: // staleRetry
+				if getErr != nil {
+					logrus.Warnf("[K8s] unable to confirm stale secret with a live read: %v; retrying in %s", getErr, probePeriod)
+				} else {
+					logrus.Warnf("[K8s] live read also older than last applied (attempt %d of %d); retrying in %s", attempt, maxConsecutiveStaleReads, probePeriod)
+				}
+				core.Secret().EnqueueAfter(w.connInfo.Namespace, w.connInfo.SecretName, probePeriod)
+				return secret, nil
+			}
+		default:
+			w.noteInOrderEvent()
 		}
 
 		if planData, ok := secret.Data[PlanKey]; ok {
@@ -419,8 +501,10 @@ func (w *watcher) start(ctx context.Context, strictVerify bool) {
 			}
 			secret, err = w.updateSecret(core, secret)
 			if err != nil {
-				logrus.Fatalf("[K8s] encountered an error while attempting to update the secret: %v", err)
-				return nil, nil
+				// Terminating here left the node with a plan applied but its result
+				// unreported. Requeue with backoff instead and let the write retry.
+				logrus.Errorf("[K8s] encountered an error while attempting to update the secret: %v", err)
+				return secret, err
 			}
 			return secret, nil
 		}

--- a/pkg/k8splan/watcher_test.go
+++ b/pkg/k8splan/watcher_test.go
@@ -1,0 +1,168 @@
+package k8splan
+
+import (
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestToInt(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"0", 0},
+		{"839896925", 839896925},
+		{"notanumber", 0},
+	} {
+		if got := toInt(tc.in); got != tc.want {
+			t.Errorf("toInt(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLiveResourceVersion(t *testing.T) {
+	if got := liveResourceVersion(nil); got != "" {
+		t.Errorf("liveResourceVersion(nil) = %q, want empty", got)
+	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "42"}}
+	if got := liveResourceVersion(secret); got != "42" {
+		t.Errorf("liveResourceVersion = %q, want %q", got, "42")
+	}
+}
+
+// TestResolveStaleReadUsesLive is the fix for the reported wedge: an informer
+// relist against a lagging apiserver hands the agent an older resourceVersion
+// than the one it last wrote. Confirming with a live read establishes ground
+// truth and lets the reconcile continue, instead of returning a hard error.
+func TestResolveStaleReadUsesLive(t *testing.T) {
+	for _, tc := range []struct{ name, lastApplied, live string }{
+		{"live is newer", "839896925", "839896999"},
+		{"live is exactly the last applied", "839896925", "839896925"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &watcher{lastAppliedResourceVersion: tc.lastApplied, staleReadCount: 1}
+			if got := w.resolveStaleRead(tc.live, nil); got != staleUseLive {
+				t.Errorf("action = %v, want staleUseLive", got)
+			}
+			if w.staleReadCount != 0 {
+				t.Errorf("staleReadCount = %d, want it reset to 0", w.staleReadCount)
+			}
+			if w.lastAppliedResourceVersion != tc.lastApplied {
+				t.Errorf("lastAppliedResourceVersion = %q, want it untouched (%q)",
+					w.lastAppliedResourceVersion, tc.lastApplied)
+			}
+		})
+	}
+}
+
+// TestResolveStaleReadGetError: a failed live read is not evidence of anything.
+// Retry without engaging the controller's failure rate limiter, and without
+// advancing the streak toward a forced resync.
+func TestResolveStaleReadGetError(t *testing.T) {
+	w := &watcher{lastAppliedResourceVersion: "839896925", staleReadCount: 1}
+	if got := w.resolveStaleRead("", errors.New("apiserver unavailable")); got != staleRetry {
+		t.Errorf("action = %v, want staleRetry", got)
+	}
+	if w.staleReadCount != 1 {
+		t.Errorf("staleReadCount = %d, want it unchanged at 1", w.staleReadCount)
+	}
+	if w.lastAppliedResourceVersion != "839896925" {
+		t.Errorf("lastAppliedResourceVersion = %q, want it untouched", w.lastAppliedResourceVersion)
+	}
+}
+
+// TestResolveStaleReadForcesResyncAfterThreshold: when even the live read stays
+// behind, the agent must eventually stop trusting its remembered resourceVersion
+// rather than looping forever. This is the escape hatch from the reported
+// deadlock.
+func TestResolveStaleReadForcesResyncAfterThreshold(t *testing.T) {
+	w := &watcher{lastAppliedResourceVersion: "839896925"}
+
+	for i := 1; i < maxConsecutiveStaleReads; i++ {
+		if got := w.resolveStaleRead("839896677", nil); got != staleRetry {
+			t.Fatalf("attempt %d: action = %v, want staleRetry", i, got)
+		}
+		if w.staleReadCount != i {
+			t.Fatalf("attempt %d: staleReadCount = %d, want %d", i, w.staleReadCount, i)
+		}
+		if w.lastAppliedResourceVersion == "" {
+			t.Fatalf("attempt %d: lastAppliedResourceVersion was reset too early", i)
+		}
+	}
+
+	if got := w.resolveStaleRead("839896677", nil); got != staleForceResync {
+		t.Fatalf("attempt %d: action = %v, want staleForceResync", maxConsecutiveStaleReads, got)
+	}
+	if w.lastAppliedResourceVersion != "" {
+		t.Errorf("lastAppliedResourceVersion = %q, want it cleared to force a resync",
+			w.lastAppliedResourceVersion)
+	}
+	if w.staleReadCount != 0 {
+		t.Errorf("staleReadCount = %d, want it reset to 0 after the resync", w.staleReadCount)
+	}
+}
+
+// TestResolveStaleReadRecoveryResetsStreak: a recovered live read must clear the
+// streak so an unrelated stale observation later does not tip a fresh agent
+// straight into a forced resync.
+func TestResolveStaleReadRecoveryResetsStreak(t *testing.T) {
+	w := &watcher{lastAppliedResourceVersion: "100"}
+
+	if got := w.resolveStaleRead("50", nil); got != staleRetry {
+		t.Fatalf("action = %v, want staleRetry", got)
+	}
+	if got := w.resolveStaleRead("150", nil); got != staleUseLive {
+		t.Fatalf("action = %v, want staleUseLive", got)
+	}
+	if w.staleReadCount != 0 {
+		t.Fatalf("staleReadCount = %d, want 0 after recovery", w.staleReadCount)
+	}
+
+	// The streak restarts from scratch: it must take the full threshold again.
+	for i := 1; i < maxConsecutiveStaleReads; i++ {
+		if got := w.resolveStaleRead("50", nil); got != staleRetry {
+			t.Fatalf("post-recovery attempt %d: action = %v, want staleRetry", i, got)
+		}
+	}
+	if got := w.resolveStaleRead("50", nil); got != staleForceResync {
+		t.Errorf("action = %v, want staleForceResync", got)
+	}
+}
+
+// TestResolveStaleReadAfterResyncTreatsLiveAsCurrent: once
+// lastAppliedResourceVersion is cleared, any live read is by definition current,
+// so the next pass must proceed rather than immediately re-entering the streak.
+func TestResolveStaleReadAfterResyncTreatsLiveAsCurrent(t *testing.T) {
+	w := &watcher{lastAppliedResourceVersion: ""}
+	if got := w.resolveStaleRead("50", nil); got != staleUseLive {
+		t.Errorf("action = %v, want staleUseLive once the remembered version is cleared", got)
+	}
+}
+
+// TestNoteInOrderEventEndsTheStreak guards the meaning of
+// maxConsecutiveStaleReads. The watcher calls noteInOrderEvent from the default
+// arm of its switch, on every event that arrives in order; drop that call and
+// the counter becomes cumulative, so three unrelated stale observations spread
+// over an agent's lifetime would force a resync — and a resync re-runs one-time
+// instructions.
+func TestNoteInOrderEventEndsTheStreak(t *testing.T) {
+	w := &watcher{lastAppliedResourceVersion: "100", staleReadCount: maxConsecutiveStaleReads - 1}
+
+	w.noteInOrderEvent()
+	if w.staleReadCount != 0 {
+		t.Fatalf("staleReadCount = %d, want 0", w.staleReadCount)
+	}
+
+	// One stale read after an in-order event must not be enough to force a
+	// resync, which it would have been without the reset.
+	if got := w.resolveStaleRead("50", nil); got != staleRetry {
+		t.Errorf("action = %v, want staleRetry — the streak should have restarted", got)
+	}
+	if w.lastAppliedResourceVersion != "100" {
+		t.Errorf("lastAppliedResourceVersion = %q, want it untouched", w.lastAppliedResourceVersion)
+	}
+}


### PR DESCRIPTION
## Issue: https://github.com/rancher/system-agent/issues/403

## Problem

The watcher compared the incoming secret's `resourceVersion` against the last one it applied and, if the incoming one was lower, gave up:

```go
case rvIsOlder:
    logrus.Errorf("[K8s] received secret to process that was older than the last secret operated on. (%s vs %s)",
        secret.ResourceVersion, w.lastAppliedResourceVersion)
    return secret, errors.New("secret received was too old")
```

Two things are wrong with this.

**`resourceVersion` is opaque.** The Kubernetes API contract is explicit that clients must not order it or interpret it numerically. An informer relist served by a lagging etcd member legitimately produces one lower than what the client last saw — the value has not "gone backwards" in any meaningful sense; the client is simply reading a replica that has not caught up.

**Returning an error cannot help.** It requeues *the same cached object* through the controller's failure rate limiter, capped at five minutes. The next attempt reads the same informer cache and makes the same comparison against the same remembered value. Nothing in the loop can change its outcome. There is no path out of it that does not involve a human.

On the reported cluster this logged

```
secret received was too old (839896677 vs 839896925)
```

indefinitely. The node never picked up another plan, and the only escape was deleting the plan secret by hand — long after the underlying storage stall had cleared.

## Solution

Distinguish *"the informer handed me something old"* from *"the cluster is actually behind"* by establishing ground truth with a live read.

On a stale read the watcher now does a direct `core.Secret().Get`, then:

| Live read | Action |
|---|---|
| At least as new as the last applied | Reconcile against it, and end any run of stale reads |
| Also behind | `EnqueueAfter` and **return `nil`**, so the failure rate limiter is not engaged |
| Also behind, 3 consecutive times | Drop the remembered `resourceVersion` and reconcile anyway |

The decision is extracted into `resolveStaleRead`, which returns a `staleReadAction` and advances the counter. This keeps the state machine testable without standing up a fake API server — `start()` is a ~400-line closure over a live controller factory.

Three details that are easy to get wrong:

**The counter is consecutive, not cumulative.** `noteInOrderEvent` clears it from the `default:` arm of the switch, on every event that arrives in order. Without that, three unrelated stale observations spread over an agent's lifetime would add up to a forced resync — and **a resync re-runs one-time instructions**, which is not something to trigger by accident.

**A failed live read leaves the streak untouched.** It is not evidence of staleness, only of not being able to check. It retries without advancing toward the escape hatch and without engaging the rate limiter.

**`getErr == nil && live == nil` is turned into an error.** Both proceeding branches call `live.DeepCopy()`; a client returning a nil object alongside a nil error would panic. `liveResourceVersion` is nil-safe for the same reason.

### Also in this PR

`logrus.Fatalf` on an `updateSecret` failure becomes `Errorf` plus a returned error. Terminating there left the node with **the plan applied but its result unreported** — the orchestrator sees no progress, and the exit is also what leaves an interlock file behind (see PRs A–C). Returning the error requeues with backoff and lets the write retry.

This is a small change in a large file and could be split out, but it belongs to the same failure story: it is the other way this reconcile loop turned a transient apiserver problem into a permanent one.

### Alternatives considered

**Stop tracking `resourceVersion` altogether.** It exists to avoid re-applying a plan the agent has already handled after a relist. Removing it trades a wedge for redundant applies of one-time instructions, which is worse.

**Compare `generation` instead.** Secrets have no meaningful `generation`.

**Trust the live read unconditionally on the first stale event.** Simpler, and it fixes the reported case. But if the live read is *also* stale — the apiserver itself is behind, which is what the ticket describes — the agent would apply against a genuinely old plan. Requiring three consecutive confirmations before abandoning the remembered version is the conservative middle.

**Return the error but with a bounded retry budget.** Does not help: the error path re-reads the same cached object, so more attempts produce the same result. The live read is the part that adds information.

### Known limitations

- `toInt` still parses `resourceVersion` as an integer, which the API contract does not guarantee. That ordering assumption is pre-existing and not removed here — this PR makes the consequences of it being wrong recoverable rather than terminal. Removing it entirely is a larger change.
- Three consecutive stale live reads is a heuristic. Tuned so a genuinely lagging apiserver gets ~3 probe periods to catch up before the agent stops trusting its own memory.
- A forced resync re-runs one-time instructions. Those are expected to be idempotent, but this makes the assumption load-bearing in a new place.

#### Manual Testing

**This is the hardest of the four to reproduce manually**, because it needs an apiserver that serves a `resourceVersion` older than one the agent has already seen. Ordered from most realistic to most practical.

**D1 — The natural reproduction (closest to the ticket).** On an HA cluster with 3 etcd members:

```sh
# Identify the node's plan secret and watch the agent.
kubectl -n fleet-default get secret <cluster>-<machine>-machine-plan -o yaml | grep resourceVersion
journalctl -u rancher-system-agent -f
```

1. Apply a plan so the agent records a `lastAppliedResourceVersion`.
2. Degrade one etcd member so its apiserver lags — network-delay it (`tc qdisc add dev eth0 root netem delay 2000ms`), or stall its disk. This is what the 3.4s `fdatasync` in the ticket did naturally.
3. Force the agent to relist (restart it, or let the informer resync) while pointed at the lagging apiserver.

Expect on `main`: `secret received was too old (X vs Y)` repeating forever, node never applies another plan.
Expect on this branch: `confirming with a live read`, then either `proceeding with it` or up to three `live read also older than last applied (attempt N of 3)` followed by `resetting last applied resource version and resyncing`. Either way the node recovers **without intervention**.

**D2 — Regress `resourceVersion` via an etcd snapshot restore.** Blunter, but deterministic and does not need a degraded network:

1. `rke2 etcd-snapshot save`
2. Let the agent apply a plan (the secret's RV advances).
3. Restore the snapshot — RVs regress below what the agent remembers.
4. Watch the agent.

Heavy-handed for a single test, but it produces exactly the condition.

**D3 — Force the counter, no cluster damage needed.** Confirms the escape hatch specifically:

Set `maxConsecutiveStaleReads = 1` in a scratch build, then trigger a single stale read by any of the above. The agent should force a resync on the first occurrence instead of the third. Confirms the arm is reachable in production code, not just in the unit tests.

**D4 — Regression check on a healthy cluster (do this one regardless).** By far the most important manual test, because the change sits in the main reconcile path:

```sh
journalctl -u rancher-system-agent -f
```

Provision a cluster, apply several plans, restart the agent between them, delete and recreate the plan secret, scale a node pool. Expect **no** `confirming with a live read` messages at all on a healthy cluster — the new code should be entirely dormant. Any appearance means the `rvIsOlder` branch is being hit in normal operation, which would be worth understanding before merge.

**D5 — The `updateSecret` change.** Make a write fail and confirm the agent survives:

```sh
# Block the agent's writes at the API level, e.g. by revoking the secret's
# update permission, or by partitioning the node from the apiserver mid-apply.
journalctl -u rancher-system-agent -f | grep -i "attempting to update the secret"
```

Expect: `encountered an error while attempting to update the secret: …` and the **process still running**, retrying with backoff. On `main` the agent exits, and systemd restarts it into the same failure.

#### Automated Testing

`pkg/k8splan/watcher_test.go` — 8 tests, all on the extracted state machine so they run in milliseconds with no API server:

- `TestToInt`, `TestLiveResourceVersion` — including the nil-secret case
- `TestResolveStaleReadUsesLive` — live newer, and live exactly equal
- `TestResolveStaleReadGetError` — streak untouched, remembered version untouched
- `TestResolveStaleReadForcesResyncAfterThreshold` — asserts the version is *not* cleared early, then is cleared exactly at the threshold
- `TestResolveStaleReadRecoveryResetsStreak` — after a recovery it must take the **full** threshold again
- `TestResolveStaleReadAfterResyncTreatsLiveAsCurrent` — a cleared version must not immediately re-enter the streak
- `TestNoteInOrderEventEndsTheStreak` — exercises the method the `default:` arm calls

**Mutation testing.** Each reverted behaviour fails the intended test:

| Mutation | Caught by |
|---|---|
| Never force a resync | `TestResolveStaleReadForcesResyncAfterThreshold`, `TestResolveStaleReadRecoveryResetsStreak` |
| `noteInOrderEvent` made a no-op | `TestResolveStaleReadUsesLive`, `TestResolveStaleReadRecoveryResetsStreak`, `TestNoteInOrderEventEndsTheStreak` |
| A failed `Get` advances the streak | `TestResolveStaleReadGetError` |

Full suite green: `go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...`.

### QA Testing Considerations

- **The regression risk outweighs the fix risk here.** This code sits in the main reconcile path for every plan on every node. D4 (healthy-cluster regression sweep) matters more than reproducing the wedge.
- The natural trigger is a **lagging etcd member under storage pressure**, not a healthy cluster. Any environment that can degrade one member's disk or network reproduces it.
- Worth combining with the secret-recreated path (`uidChanged`), which shares the same switch and also resets `staleReadCount`.
- A forced resync **re-runs one-time instructions**. Confirm that is safe for the plans in your matrix — particularly anything that is not obviously idempotent.
- Confirm the agent no longer exits on a secret write failure (D5). That behaviour change is independently observable.

### Regressions Considerations

- **An extra API call per stale read.** Only on the `rvIsOlder` path, which should be rare. If it turns out to be common on healthy clusters, this becomes load on the apiserver — D4 is the check for that.
- **`EnqueueAfter` + `return nil` deliberately bypasses the failure rate limiter.** Correct for a transient stale read, but it means a persistently lagging apiserver is retried every `probePeriod` rather than backing off exponentially. Bounded by the 3-attempt escape hatch.
- **Forced resync re-runs one-time instructions.** The largest behavioural change in the PR. Guarded by the consecutive-not-cumulative counter, which is why `noteInOrderEvent` exists and is tested directly.
- **No longer exiting on `updateSecret` failure** changes a failure mode from "process dies, systemd restarts it" to "process retries with backoff". Better, but it means a persistent write failure now shows up as log noise rather than a restart loop — different signal for anyone monitoring on restarts.
- **The `errors` import was dropped** from `watcher.go`; `apierrors` is unaffected.
